### PR TITLE
Small changes to calendar design

### DIFF
--- a/make_queue/models.py
+++ b/make_queue/models.py
@@ -54,7 +54,7 @@ class Machine(models.Model):
 
     def get_status_display(self):
         current_status = self.get_status()
-        return next(full_name for short_hand, full_name in self.status_choices if short_hand == current_status)
+        return [full_name for short_hand, full_name in self.status_choices if short_hand == current_status][0]
 
 
 class Printer3D(Machine):

--- a/make_queue/static/make_queue/css/calendar.css
+++ b/make_queue/static/make_queue/css/calendar.css
@@ -1,22 +1,30 @@
 .make_reservation_calendar_time_table_event {
     background-color: #21ba45;
-}
-
-.make_reservation_calendar_time_table_event:hover {
-    cursor: pointer;
+    border-top: 1px solid #1b8f3a;
+    border-bottom: 1px solid #1b8f3a;
 }
 
 .make_reservation_calendar_time_table_non_event {
     background-color: #2185d0;
+    border-top: 1px solid #1b629d;
+    border-bottom: 1px solid #1b629d;
 }
 
 .make_reservation_calendar_time_table_my_non_event {
-    background-color: rgb(248, 200, 17);
+    background-color: #f8c811;
+    border-top: 1px solid #d7ab0f;
+    border-bottom: 1px solid #d7ab0f;
 }
 
 .make_reservation_calendar_time_table_make {
     background-color: #dcddde;
+    border-top: 1px solid #babbbc;
+    border-bottom: 1px solid #babbbc;
     z-index: 200;
+}
+
+.make_reservation_calendar_time_table_event:hover {
+    cursor: pointer;
 }
 
 .make_reservation_calendar_legend_box {

--- a/make_queue/static/make_queue/css/calendar.css
+++ b/make_queue/static/make_queue/css/calendar.css
@@ -169,3 +169,11 @@ td.wrapping {
     height: 1px !important;
     padding: 0 !important;
 }
+
+.current_time_indicator {
+    width: 100%;
+    height: 2px;
+    background-color: #ff0000;
+    position: absolute;
+    z-index: 300;
+}

--- a/make_queue/static/make_queue/css/calendar.css
+++ b/make_queue/static/make_queue/css/calendar.css
@@ -170,10 +170,20 @@ td.wrapping {
     padding: 0 !important;
 }
 
+tr.wrapping {
+    height: 100% !important;
+}
+
 .current_time_indicator {
     width: 100%;
     height: 2px;
     background-color: #ff0000;
     position: absolute;
     z-index: 300;
+}
+
+@-moz-document url-prefix() {
+    td.wrapping {
+        height: 100% !important;
+    }
 }

--- a/make_queue/templates/make_queue/reservation_calendar.html
+++ b/make_queue/templates/make_queue/reservation_calendar.html
@@ -59,6 +59,10 @@
                         {% for line in num_indication_lines %}
                             <div class="hour_indication_line"></div>
                         {% endfor %}
+                        {% is_current_date day.date.date as should_include_current_time_indicator %}
+                        {% if should_include_current_time_indicator %}
+                            <div class="current_time_indicator" style="top: {% get_current_time_of_day %}%"></div>
+                        {% endif %}
                         {% for reservation in day.reservations %}
                             {% if reservation.length %}
                                 <div class="make_reservation_calendar_time_table_item

--- a/make_queue/templates/make_queue/reservation_calendar.html
+++ b/make_queue/templates/make_queue/reservation_calendar.html
@@ -85,6 +85,9 @@
                                                 </div>
                                                 <div>
                                                     <b>Epost:</b> {{ reservation.reservation.user.email }}
+                                                </div>
+                                                <div>
+                                                    <b>Tidspunkt:</b> {{ reservation.reservation.start_time|date:"D H:i"|title }} - {{ reservation.reservation.end_time|date:"D H:i"|title }}
                                                 </div>"
                                         {% endif %}>
                                 </div>

--- a/make_queue/templates/make_queue/reservation_calendar.html
+++ b/make_queue/templates/make_queue/reservation_calendar.html
@@ -42,7 +42,7 @@
             {% endfor %}
         </tr>
         </thead>
-        <tr>
+        <tr class="wrapping">
             <td class="wrapping">
                 <div class="half_height"></div>
                 {% numeric_range 1 24 as hours %}

--- a/make_queue/templates/make_queue/reservation_calendar.html
+++ b/make_queue/templates/make_queue/reservation_calendar.html
@@ -15,7 +15,7 @@
         <a class="ui make_yellow button bordered"
            id="now_button" {% if link_now %}href="{{ link_now }}"{% endif %}>
             <i class="calendar icon"></i>
-            Nå (Uke {{ now.date|date:"W" }})
+            I dag
         </a>
         <a class="ui right labeled icon make_yellow button" id="next_week_button"
            {% if link_next %}href="{{ link_next }}"{% endif %}>


### PR DESCRIPTION
- Adds a red bar indicating the current time
- Adds borders on the top and bottom of reservations to easier distinguish two consecutive reservations
- Change the text displayed in the calendar navigation bar to make it easier to understand
- Tries to fix the weird server bug, where the status text of a machine is sometimes incorrect