### PR TITLE
Fix appearance of reservation calendar in Firefox

### DIFF
--- a/make_queue/static/make_queue/css/calendar.css
+++ b/make_queue/static/make_queue/css/calendar.css
@@ -182,7 +182,7 @@ tr.wrapping {
     z-index: 300;
 }
 
-@-moz-document url-prefix() {
+@supports (-moz-appearance:none) {
     td.wrapping {
         height: 100% !important;
     }


### PR DESCRIPTION
@-moz-document url-prefix() is no longer supported

Fixes #131 