### PR TITLE
Fix for navbar user dropdown on mobile.

### DIFF
--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -35,8 +35,7 @@
         </a>
         {% if user.is_authenticated %}
             <div class="ui dropdown item">
-                <div class="text">{{ user.first_name|first_word }}</div>
-                <i class="dropdown icon"></i>
+                {{ user.first_name|first_word }} <i class="dropdown icon"></i>
                 <div class="menu">
                     {% if user|has_any_permissions or user.is_superuser %}
                         <a class="item" href="{% url 'adminpanel' %}">
@@ -52,7 +51,7 @@
                 </div>
             </div>
             {% block scripts %}
-                <script>$('.dropdown').dropdown();</script>
+                <script>$('.ui.dropdown').dropdown();</script>
             {% endblock scripts %}
         {% else %}
             <a class="item" href="{% url 'login' %}">

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -90,7 +90,7 @@
 </form>
 
 <script>
-    $('#nav-user-dropdown').dropdown(action="nothing");
+    $('#nav-user-dropdown').dropdown(action="select");
     $(".lang-link").click(function (event) {
         event.preventDefault();
         $(".lang-form").submit();

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -90,7 +90,7 @@
 </form>
 
 <script>
-    $('#nav-user-dropdown').dropdown(action="select");
+    $('#nav-user-dropdown').dropdown({action: "nothing"});
     $(".lang-link").click(function (event) {
         event.preventDefault();
         $(".lang-form").submit();

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -36,7 +36,7 @@
         {% if user.is_authenticated %}
             <div class="ui dropdown item">
                 {{ user.first_name|first_word }} <i class="dropdown icon"></i>
-                <div class="menu">
+                <div class="menu transition hidden">
                     {% if user|has_any_permissions or user.is_superuser %}
                         <a class="item" href="{% url 'adminpanel' %}">
                             {% trans "Administration" %}

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -34,7 +34,7 @@
             {% trans "Reservations" %}
         </a>
         {% if user.is_authenticated %}
-            <div class="ui dropdown item">
+            <div class="ui dropdown item" id="nav-user-dropdown">
                 {{ user.first_name|first_word }} <i class="dropdown icon"></i>
                 <div class="menu transition hidden">
                     {% if user|has_any_permissions or user.is_superuser %}
@@ -50,9 +50,6 @@
                     </a>
                 </div>
             </div>
-            {% block scripts %}
-                <script>$('.ui.dropdown').dropdown();</script>
-            {% endblock scripts %}
         {% else %}
             <a class="item" href="{% url 'login' %}">
                 {% trans "Login" %}
@@ -93,10 +90,11 @@
 </form>
 
 <script>
+    $('#nav-user-dropdown').dropdown();
     $(".lang-link").click(function (event) {
         event.preventDefault();
         $(".lang-form").submit();
-    })
+    });
     $('.burger').click(function () {
         $('.nav').toggleClass('active');
     });

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -90,7 +90,7 @@
 </form>
 
 <script>
-    $('#nav-user-dropdown').dropdown();
+    $('#nav-user-dropdown').dropdown(action="nothing");
     $(".lang-link").click(function (event) {
         event.preventDefault();
         $(".lang-form").submit();


### PR DESCRIPTION
Fixes two issues with the user dropdown on mobile.
- The dropdown is now initially closed
- `.dropdown()` was called on the dropdown icon, creating an extra div

Also fixes an issue, where Cmd/Ctrl clicking a link in the dropdown would change the dropdown text (the name), to the text of the selected link.