### PR TITLE
Short reservation fix

### DIFF
--- a/make_queue/models/models.py
+++ b/make_queue/models/models.py
@@ -248,6 +248,9 @@ class ReservationRule(models.Model):
         if timedelta_to_hours(end_time - start_time) > max(rule.max_hours for rule in rules):
             return False
 
+        if timedelta_to_hours(end_time - start_time) <= min(rule.max_hours for rule in rules):
+            return True
+
         return all(rule.valid_time_in_rule(start_time, end_time, len(rules) > 1) for rule in rules)
 
     class Period:

--- a/make_queue/templates/make_queue/js/reservation_rules.html
+++ b/make_queue/templates/make_queue/js/reservation_rules.html
@@ -79,6 +79,18 @@
         if (coveredRules.length === 1) {
             return coveredRules[0].max_inside >= hoursInsideRule(coveredRules[0], startTime, endTime).toPrecision(2);
         }
+
+        // If the reservation is shorter than the maximum inside for any of the rules, it should also be valid for
+        // the whole duration, even though it breaks with one or more of the max_crossed rules.
+        let minTime = 168;
+        for (let ruleIndex = 0; ruleIndex < coveredRules.length; ruleIndex++) {
+            minTime = Math.min(minTime, coveredRules[ruleIndex].max_inside);
+        }
+
+        if (minTime >= (endTime.valueOf() - startTime.valueOf()) / (60 * 60 * 1000)) {
+            return true;
+        }
+
         let maxTime = 0;
         for (let ruleIndex = 0; ruleIndex < coveredRules.length; ruleIndex++) {
             maxTime = Math.max(maxTime, coveredRules[ruleIndex].max_inside);
@@ -101,8 +113,10 @@
 
             // Check if the total time of the reservation is greater than what is allowed by the covered rules
             let maxTime = 0;
+            let minTime = 168;
             for (let ruleIndex = 0; ruleIndex < coveredRules.length; ruleIndex++) {
                 maxTime = Math.max(maxTime, coveredRules[ruleIndex].max_inside);
+                minTime = Math.min(minTime, coveredRules[ruleIndex].max_inside);
             }
 
             // Modify the start/end time based on the maximum allowed time for the covered rules
@@ -127,7 +141,10 @@
                 } else if (currentOverlap > period.max_crossed) {
                     // If the overlap with the current time period is greater than the maximum allowed when multiple
                     // time periods are selected, then shrink till it is equal to that.
-                    endTime = new Date(endTime.valueOf() - (currentOverlap - period.max_crossed) * 60 * 60 * 1000);
+                    endTime = new Date(Math.max(
+                        new Date(endTime.valueOf() - (currentOverlap - period.max_crossed) * 60 * 60 * 1000),
+                        new Date(startTime.valueOf() + minTime * 60 * 60 * 1000)
+                    ));
                 } else {
                     // If the overlap is smaller than both the allowed inside when single- and multi-period, shrink till
                     // there is no overlap between the periods.
@@ -142,7 +159,10 @@
                 } else if (currentOverlap > period.max_crossed) {
                     // If the overlap with the current time period is greater than the maximum allowed when multiple
                     // time periods are selected, then shrink till it is equal to that.
-                    startTime = new Date(startTime.valueOf() + (currentOverlap - period.max_crossed) * 60 * 60 * 1000);
+                    startTime = new Date(Math.min(
+                        new Date(startTime.valueOf() + (currentOverlap - period.max_crossed) * 60 * 60 * 1000),
+                        new Date(endTime.valueOf() - minTime * 60 * 60 * 1000)
+                    ));
                 } else {
                     // If the overlap is smaller than both the allowed inside when single- and multi-period, shrink till
                     // there is no overlap between the periods.

--- a/make_queue/tests/models/test_reservation_rules.py
+++ b/make_queue/tests/models/test_reservation_rules.py
@@ -215,3 +215,8 @@ class ReservationRuleTests(TestCase):
         self.assertFalse(ReservationRule.valid_time(datetime.datetime(2018, 11, 6, 0, 0),
                                                     datetime.datetime(2018, 11, 6, 12, 0), self.machine_type),
                          "A period may not be valid in one of the rules is covers")
+
+        self.assertTrue(ReservationRule.valid_time(datetime.datetime(2018, 11, 6, 0, 0),
+                                                   datetime.datetime(2018, 11, 6, 10, 0), self.machine_type),
+                        "A period may be valid, even though not all of its rules are valid, if it is still less than"
+                        "the shortest maximum length of any of its rules.")


### PR DESCRIPTION
Fixes an issue in where a reservation shorter than the smallest `max_inside` value of the rules it covered, would be invalid. Now all rules that are shorter than the smallest `max_inside` value of the rules they cover will be valid.