### PR TITLE
Force selection option on Semantic UI searchable select widget

### DIFF
--- a/web/templates/web/forms/widgets/semantic_search_select.html
+++ b/web/templates/web/forms/widgets/semantic_search_select.html
@@ -23,5 +23,8 @@
     </div>
 </div>
 <script>
-    $("#{{ widget.name }}").parent().dropdown({fullTextSearch: true});
+    $("#{{ widget.name }}").parent().dropdown({
+        fullTextSearch: true,
+        forceSelection: {{ widget.attrs.force_selection|lower }}
+    });
 </script>

--- a/web/widgets.py
+++ b/web/widgets.py
@@ -16,10 +16,8 @@ class SemanticSearchableChoiceInput(forms.Select):
 
     def __init__(self, *args, **kwargs):
         super().__init__()
-        if "prompt_text" in kwargs:
-            self.attrs["prompt_text"] = kwargs["prompt_text"]
-        else:
-            self.attrs["prompt_text"] = self.prompt_text
+        self.attrs["prompt_text"] = kwargs.pop("prompt_text", self.prompt_text)
+        self.attrs["force_selection"] = kwargs.pop("force_selection", False)
 
 
 class SemanticDateInput(forms.DateInput):


### PR DESCRIPTION
Allow a form to specify if its Semantic UI searchable select widget should force selection of an element. Is set to False by default.

Fixes an issue in the course registration tab where a user was autoselected.