### PR TITLE
Websocket Reconfiguration

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -81,6 +81,10 @@ CHANNEL_LAYERS = {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
             'hosts': [(REDIS_IP, REDIS_PORT)],
+            # The maximum resend time of a message in seconds
+            'expiry': 30,
+            # The number of seconds before a connection expires
+            'group_expiry': 900,
         },
     },
 }


### PR DESCRIPTION
Fixes an issue in which the streams sometimes fail to propagate data correctly. Previously, the timeout for the stream was by default 24 hours. This left the server with too many open channels and it could not handle new incoming websocket connections. A new timeout of 15 minutes has been set, as users that have not received messages in 15 minutes are highly unlikely to reconnect.