### PR TITLE
Improve static file caching with hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ install:
 
 # command to run tests
 script:
+  # Necessary for generating staticfiles manifest entries
+  # used by Django's `ManifestStaticFilesStorage`:
+  - python manage.py collectstatic --no-input
   - coverage run --source='.' manage.py test
 
 # command to run after success

--- a/web/settings.py
+++ b/web/settings.py
@@ -200,7 +200,12 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
+STATIC_ROOT = os.path.join(BASE_DIR, "../static")
 STATIC_URL = '/static/'
+
+# ManifestStaticFilesStorage appends every static file's MD5 hash to its filename,
+# which avoids waiting for browsers' cache to update if a file's contents change
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 CKEDITOR_UPLOAD_PATH = 'ckeditor-upload/'
 CKEDITOR_IMAGE_BACKEND = 'pillow'


### PR DESCRIPTION
See the commit message for details.

This will remove the need to clear browsers' cache each time we make any changes to the static files. Deployment will not be any different than before, except that running the `collectstatic` command will take a few seconds longer while Django recalculates the static files' hashes.

With this change, it's recommended to increase our static files' `max-age` (a directive of the `Cache-Control` HTTP header field), which removes the need for browsers to occasionally update the cached files. We can do this by adding `expires max;` to `location /static {}` in the Nginx config file.