### PR TITLE
Fixes failing reservation tests

### DIFF
--- a/make_queue/tests/views/test_reservation_calendar_view.py
+++ b/make_queue/tests/views/test_reservation_calendar_view.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytz
 from django.contrib.auth.models import User
@@ -29,38 +30,47 @@ class ReservationCalendarComponentViewTestCase(TestCase):
                                    event=None)
         return Reservation.objects.first()
 
-    def test_format_reservation_start_end_same_day(self):
-        date = pytz.timezone(timezone.get_default_timezone_name()).localize(
+    @mock.patch("make_queue.util.time.timezone.get_default_timezone")
+    def test_format_reservation_start_end_same_day(self, get_default_timezone_mock):
+        # Set default timezone to UTC
+        get_default_timezone_mock.return_value = timezone.get_fixed_timezone(0)
+        date = pytz.timezone("UTC").localize(
             datetime.combine(timezone.now().date() + timedelta(days=1), datetime.min.time()))
         reservation = self.create_reservation(date + timedelta(hours=12), date + timedelta(hours=18))
         self.assertEqual(ReservationCalendarComponentView.format_reservation(reservation, date), {
             'reservation': reservation,
             'start_percentage': 50,
-            'start_time': "11:00",
-            'end_time': "17:00",
+            'start_time': "12:00",
+            'end_time': "18:00",
             'length': 25
         })
 
-    def test_format_reservation_start_day_before(self):
-        date = pytz.timezone(timezone.get_default_timezone_name()).localize(
+    @mock.patch("make_queue.util.time.timezone.get_default_timezone")
+    def test_format_reservation_start_day_before(self, get_default_timezone_mock):
+        # Set default timezone to UTC
+        get_default_timezone_mock.return_value = timezone.get_fixed_timezone(0)
+        date = pytz.timezone("UTC").localize(
             datetime.combine(timezone.now().date() + timedelta(days=1), datetime.min.time()))
         reservation = self.create_reservation(date + timedelta(hours=12), date + timedelta(days=1, hours=6))
         self.assertEqual(ReservationCalendarComponentView.format_reservation(reservation, date + timedelta(days=1)), {
             'reservation': reservation,
             'start_percentage': 0,
             'start_time': "00:00",
-            'end_time': "05:00",
+            'end_time': "06:00",
             "length": 25
         })
 
-    def test_format_reservation_end_day_after(self):
-        date = pytz.timezone(timezone.get_default_timezone_name()).localize(
+    @mock.patch("make_queue.util.time.timezone.get_default_timezone")
+    def test_format_reservation_end_day_after(self, get_default_timezone_mock):
+        # Set default timezone to UTC
+        get_default_timezone_mock.return_value = timezone.get_fixed_timezone(0)
+        date = pytz.timezone("UTC").localize(
             datetime.combine(timezone.now().date() + timedelta(days=1), datetime.min.time()))
         reservation = self.create_reservation(date + timedelta(hours=12), date + timedelta(days=1, hours=4))
         self.assertEqual(ReservationCalendarComponentView.format_reservation(reservation, date), {
             'reservation': reservation,
             'start_percentage': 50,
-            'start_time': '11:00',
+            'start_time': '12:00',
             'end_time': "23:59",
             'length': 50 - 100 / 1440
         })


### PR DESCRIPTION
Fixes tests that where failing due to the change from CET to CEST on the 31th of March. 