### PR TITLE
Upgrade to Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ notifications:
   email: false
 
 # code language
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/internal/views.py
+++ b/internal/views.py
@@ -44,7 +44,7 @@ class EditMemberView(UserPassesTestMixin, UpdateView):
     form_class = EditMemberForm
 
     def test_func(self):
-        return self.request.user == self.object.user or self.request.user.has_perm("internal.can_edit_group_membership")
+        return self.request.user == self.get_object().user or self.request.user.has_perm("internal.can_edit_group_membership")
 
     def get_form(self, form_class=None):
         if form_class is None:

--- a/make_queue/models/models.py
+++ b/make_queue/models/models.py
@@ -54,7 +54,12 @@ class Machine(models.Model):
             return self.status
         return self.reservations_in_period(timezone.now(), timezone.now() + timedelta(seconds=1)) and "R" or "F"
 
-    def get_status_display(self):
+    def _get_FIELD_display(self, field):
+        if field.attname == "status":
+            return self._get_status_display()
+        return super()._get_FIELD_display(field)
+
+    def _get_status_display(self):
         current_status = self.get_status()
         return [full_name for short_hand, full_name in self.status_choices if short_hand == current_status][0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=2.1.5,<2.2.0
+django>=2.2.0,<2.3.0
 django-ckeditor==5.6.1
 Pillow
 python-social-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=2.1.5
+django>=2.1.5,<2.2.0
 django-ckeditor==5.6.1
 Pillow
 python-social-auth

--- a/web/urls.py
+++ b/web/urls.py
@@ -13,7 +13,7 @@ from social_core.utils import setting_name
 
 from contentbox.models import ContentBox
 from dataporten.views import Logout, login_wrapper
-from web.views import IndexView, AdminPanelView, View404, View500
+from web.views import IndexView, AdminPanelView, View404, view_500
 
 extra = getattr(settings, setting_name('TRAILING_SLASH'), True) and '/' or ''
 
@@ -65,4 +65,4 @@ urlpatterns += [
 ]
 
 handler404 = View404.as_view()
-handler500 = View500.as_view()
+handler500 = view_500

--- a/web/views.py
+++ b/web/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.shortcuts import render
 from django.views.generic import TemplateView
 
 from news.models import Article, TimePlace
@@ -44,8 +45,5 @@ class View404(TemplateView):
         return self.render_to_response({}, status=404)
 
 
-class View500(TemplateView):
-    template_name = "web/500.html"
-
-    def get(self, request, *args, **kwargs):
-        return self.render_to_response({}, status=500)
+def view_500(request):
+    return render(request, template_name="web/500.html", status=500)


### PR DESCRIPTION
Fixes failing tests due to Django automatically upgrading to version 2.2.0. We do not want this yet, as we have not been able to test if the website works for this version.