### PR TITLE
A quick fix to the CKEditor static finder

### DIFF
--- a/contentbox/templates/contentbox/edit.html
+++ b/contentbox/templates/contentbox/edit.html
@@ -5,6 +5,7 @@
 {% block title %}{% trans "Edit" %} {{ contentbox.title }}{% endblock title %}
 
 {% block head %}
+    <script>window.CKEDITOR_BASEPATH = '/static/ckeditor/ckeditor/';</script>
     <script type="text/javascript" src="{% static "ckeditor/ckeditor-init.js" %}"></script>
     <script type="text/javascript" src="{% static "ckeditor/ckeditor/ckeditor.js" %}"></script>
 {% endblock head %}


### PR DESCRIPTION
When using `ManifestStaticFilesStorage`, CKEditor can have some problems finding its static files, rendering many CKEditor fields useless. This should be done by setting `CKEDITOR_BASEPATH` in `settings.py`, however that hasn't worked for me. Therefore I made a quick fix that sets the variable in javascript in the `contentbox/edit` template. We can try to find a better solution later.

This fix has been manually added to the server to test it, and to make the website editable, while we discuss this.