### PR TITLE
RFID

### DIFF
--- a/checkin/local_scanner.py
+++ b/checkin/local_scanner.py
@@ -1,0 +1,22 @@
+import requests
+
+"""
+Module for testing the RFID functionality on makentnu.no when running locally and/or without an RFID scanner.
+"""
+
+
+def _card(path, card_id, secret):
+    r = requests.post(
+        "http://makentnu.local.test.pe:8000/" + path,
+        headers={"Content-type": "application/x-www-form-urlencoded"},
+        data={"card_id": card_id, "secret": secret}
+    )
+    return r.status_code, r.text
+
+
+def register(card_id="0123456789", secret=""):
+    return _card("checkin/register/card/", card_id, secret)
+
+
+def check(card_id="0123456789", secret=""):
+    return _card("checkin/post/", card_id, secret)

--- a/checkin/views.py
+++ b/checkin/views.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse

--- a/checkin/views.py
+++ b/checkin/views.py
@@ -34,8 +34,12 @@ class RFIDView(View):
         :param request: The HTTP POST request to handle. Must include a secret and the card id.
         :return: An HttpResponse.
         """
-        if request.POST.get('secret') == settings.CHECKIN_KEY:
-            card_id = request.POST.get('card_id')
+        secret = request.POST.get('secret')
+        card_id = request.POST.get('card_id')
+        if secret is None or card_id is None:
+            return HttpResponse(status=400)
+
+        if secret == settings.CHECKIN_KEY:
             if len(card_id) == 10 and card_id.isnumeric():
                 return self.card_id_valid("EM" + card_id)
             else:


### PR DESCRIPTION
Restructured the views handling requests from RFID-scanners. Also fixes the case where one were trying to check in with a `card_id` that did not have a corresonding `Profile`. Now returns a 401 error instead of 500.

The `RFIDView` handles the basic request handling and can be used by subclassing it in a similar manner as the Django form views. This also reduces code duplication.

Added some functions so it is possible to test the RFID-views locally and without an RFID-scanner.