### PR TITLE
Remove claim ticket functionality

### DIFF
--- a/news/templates/news/ticket.html
+++ b/news/templates/news/ticket.html
@@ -64,7 +64,7 @@
         </div>
     </div>
     {% if ticket.active %}
-        {% if ticket.user == request.user or ticket.user == None or perms.news.cancel_ticket %}
+        {% if ticket.user == request.user or perms.news.cancel_ticket %}
             <a class="ui red bottom attached button"
                href="{% url "cancel-ticket" ticket.uuid %}?next={{ request.path }}">
                 {% trans "Cancel ticket" %}

--- a/news/templates/news/ticket_overview.html
+++ b/news/templates/news/ticket_overview.html
@@ -8,26 +8,12 @@
 
 {% block body %}
     <div class="ui container">
-        {% if not object.user or object.user == request.user or perms.news.view_eventticket %}
+        {% if object.user == request.user or perms.news.view_eventticket %}
             <h1>{% trans "Ticket for" %} "{{ object.event.title }}{{ object.timeplace.event.title }}"</h1>
             <div>
                 <b>{% trans "Registered to" %}:</b> {{ object.name }},
                 <a href="mailto:{{ object.email }}">{{ object.email }}</a>
             </div>
-
-            {# Allow a user to register the ticket to their account if the ticket is not registered to an account #}
-            {% if not object.user %}
-                <div class="ui yellow message">
-                    {% trans "This ticket is not registered to any account." %}
-                    {% url "claim-ticket" pk=object.uuid as claim_url %}
-                    {% if request.user.is_authenticated %}
-                        {% trans "Click" %} <a href="{{ claim_url }}">{% trans "here" %}</a>
-                    {% else %}
-                        <a href="{% url "login" %}?next={{ claim_url }}">{% trans "Login" %}</a>
-                    {% endif %}
-                    {% trans "to register the ticket to your account." %}
-                </div>
-            {% endif %}
 
             {% include "news/ticket.html" with ticket=object %}
         {% else %}

--- a/news/urls.py
+++ b/news/urls.py
@@ -6,7 +6,7 @@ from news.views import EditArticleView, CreateArticleView, EditEventView, Create
     ViewEventView, AdminArticleView, ViewEventsView, ViewArticlesView, EditTimePlaceView, \
     DuplicateTimePlaceView, CreateTimePlaceView, AdminArticleToggleView, AdminEventToggleView, AdminTimeplaceToggleView, \
     DeleteArticleView, DeleteTimePlaceView, DeleteEventView, AdminEventView, EventRegistrationView, TicketView, \
-    ClaimTicketView, AdminEventTicketView, AdminTimeplaceTicketView, MyTicketsView, CancelTicketView, AdminEventsView
+    AdminEventTicketView, AdminTimeplaceTicketView, MyTicketsView, CancelTicketView, AdminEventsView
 
 urlpatterns = [
     path('admin/articles/', login_required(AdminArticleView.as_view()), name='admin-articles'),
@@ -35,7 +35,6 @@ urlpatterns = [
     path('timeplace/<int:pk>/ical/', SingleTimePlaceFeed(), name='timeplace-ical'),
     path('timeplace/<int:timeplace_pk>/register/', EventRegistrationView.as_view(), name="register-timeplace"),
     path('ticket/<uuid:pk>/', TicketView.as_view(), name="ticket"),
-    path('ticket/<uuid:pk>/claim/', login_required(ClaimTicketView.as_view()), name="claim-ticket"),
     path('ticket/<uuid:pk>/cancel/', CancelTicketView.as_view(), name="cancel-ticket"),
     path('ticket/me/', login_required(MyTicketsView.as_view()), name="my-tickets"),
 ]

--- a/news/views.py
+++ b/news/views.py
@@ -380,7 +380,7 @@ class EventRegistrationView(LoginRequiredMixin, CreateView):
         return kwargs
 
 
-class TicketView(DetailView):
+class TicketView(LoginRequiredMixin, DetailView):
     model = EventTicket
     template_name = "news/ticket_overview.html"
 
@@ -428,7 +428,7 @@ class AdminTimeplaceTicketView(TemplateView):
         return context_data
 
 
-class CancelTicketView(RedirectView):
+class CancelTicketView(LoginRequiredMixin, RedirectView):
     permanent = False
     query_string = True
     pattern_name = "ticket"

--- a/news/views.py
+++ b/news/views.py
@@ -384,9 +384,6 @@ class TicketView(DetailView):
     model = EventTicket
     template_name = "news/ticket_overview.html"
 
-    def get_context_data(self, **kwargs):
-        return super().get_context_data(**kwargs)
-
 
 class MyTicketsView(TemplateView):
     template_name = "news/my_tickets.html"
@@ -397,18 +394,6 @@ class MyTicketsView(TemplateView):
             "tickets": EventTicket.objects.filter(user=self.request.user),
         })
         return context_data
-
-
-class ClaimTicketView(RedirectView):
-    permanent = False
-    query_string = True
-    pattern_name = "ticket"
-
-    def get_redirect_url(self, *args, **kwargs):
-        ticket = get_object_or_404(EventTicket, pk=kwargs.get("pk", 0), user=None)
-        ticket.user = self.request.user
-        ticket.save()
-        return super().get_redirect_url(*args, **kwargs)
 
 
 class AdminEventTicketView(TemplateView):

--- a/news/views.py
+++ b/news/views.py
@@ -439,7 +439,7 @@ class CancelTicketView(RedirectView):
         # Allow for toggling if a ticket is canceled or not
         if self.request.user.has_perm("news.cancel_ticket"):
             ticket.active = not ticket.active
-        elif self.request.user == ticket.user or ticket.user is None:
+        elif self.request.user == ticket.user:
             ticket.active = False
         ticket.save()
 


### PR DESCRIPTION
Removes functionality for users to claim tickets that are not registered to a user. This is not longer needed because we require users to log in before registering for events.

This PR must be merged after all the events with tickets without users have happened. We must thus merge #248 first, then wait. Currently the last event for this semester is November 25, and it is unlikely that there will be any more events until January.