### PR TITLE
Fix apply URLs

### DIFF
--- a/contentbox/models.py
+++ b/contentbox/models.py
@@ -28,6 +28,14 @@ class ContentBox(models.Model):
     def path(title):
         return django_path(f'{title}/', DisplayContentBoxView.as_view(title=title), name=title)
 
+    @staticmethod
+    def multi_path(title, alt_url1, *other_alt_urls) -> tuple:
+        alt_urls = (alt_url1, *other_alt_urls)
+        return (
+            django_path(f'{title}/', DisplayContentBoxView.as_view(title=title), name=title),
+            *(django_path(f'{url}/', DisplayContentBoxView.as_view(title=title)) for url in alt_urls),
+        )
+
     class Meta:
         permissions = (
             ("can_upload_image", "Can upload image for CKEditor"),

--- a/contentbox/models.py
+++ b/contentbox/models.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url as durl
 from django.db import models
+from django.urls import path as django_path
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
@@ -25,8 +25,8 @@ class ContentBox(models.Model):
             return ContentBox.objects.create(title=title)
 
     @staticmethod
-    def url(title):
-        return durl(r'%s/$' % title, DisplayContentBoxView.as_view(title=title), name=title)
+    def path(title):
+        return django_path(f'{title}/', DisplayContentBoxView.as_view(title=title), name=title)
 
     class Meta:
         permissions = (

--- a/web/urls.py
+++ b/web/urls.py
@@ -32,7 +32,7 @@ urlpatterns += i18n_patterns(
     path('checkin/', include('checkin.urls')),
     path('committees/', include('groups.urls')),
     ContentBox.path('about'),
-    ContentBox.path('apply'),
+    *ContentBox.multi_path('apply', 'søk', 'sok'),
     ContentBox.path('makerspace'),
     ContentBox.path('cookies'),
     ContentBox.path('rules'),

--- a/web/urls.py
+++ b/web/urls.py
@@ -31,11 +31,11 @@ urlpatterns += i18n_patterns(
     path('media/<path:path>', serve, {'document_root': settings.MEDIA_ROOT}),  # local only, nginx in prod
     path('checkin/', include('checkin.urls')),
     path('committees/', include('groups.urls')),
-    ContentBox.url('about'),
-    ContentBox.url('apply'),
-    ContentBox.url('makerspace'),
-    ContentBox.url('cookies'),
-    ContentBox.url('rules'),
+    ContentBox.path('about'),
+    ContentBox.path('apply'),
+    ContentBox.path('makerspace'),
+    ContentBox.path('cookies'),
+    ContentBox.path('rules'),
     path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     prefix_default_language=False,
 )


### PR DESCRIPTION
We have been hanging up posters and handing out fliers with the URL [makentnu.no/søk](https://makentnu.no/søk), but that page doesn't exist. This PR is a hotfix for that.

Also fixes contentbox paths accepting any prefix (8b19f728933128cc282aa99e462cece60e9a0d51).