### PR TITLE
Reduction of JPEG sizes

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -82,15 +82,19 @@ class NewsBase(models.Model):
         """
         # Only check the image if there is actually an image
         if self.image:
-            image = Image.open(self.image)
-            if image.format == "JPEG":
-                output = BytesIO()
-                image.save(output, format="JPEG", quality=90)
-                output.seek(0)
+            # PIL will throw an IO error if it cannot open the image, or does not support the given format
+            try:
+                image = Image.open(self.image)
+                if image.format == "JPEG":
+                    output = BytesIO()
+                    image.save(output, format="JPEG", quality=90)
+                    output.seek(0)
 
-                self.image = InMemoryUploadedFile(output, "ImageField", self.image.name, "image/jpeg",
+                    self.image = InMemoryUploadedFile(output, "ImageField", self.image.name, "image/jpeg",
                                                   sys.getsizeof(output), None)
-            image.close()
+                image.close()
+            except IOError:
+                pass
 
         super(NewsBase, self).save(kwargs)
 

--- a/news/models.py
+++ b/news/models.py
@@ -80,15 +80,17 @@ class NewsBase(models.Model):
         while resulting in non to very minuscule reduction in quality. In almost all cases, the possible reduction in
         quality will not be visible to the naked eye.
         """
-        image = Image.open(self.image)
-        if image.format == "JPEG":
-            output = BytesIO()
-            image.save(output, format="JPEG", quality=90)
-            output.seek(0)
+        # Only check the image if there is actually an image
+        if self.image:
+            image = Image.open(self.image)
+            if image.format == "JPEG":
+                output = BytesIO()
+                image.save(output, format="JPEG", quality=90)
+                output.seek(0)
 
-            self.image = InMemoryUploadedFile(output, "ImageField", self.image.name, "image/jpeg",
-                                              sys.getsizeof(output), None)
-        image.close()
+                self.image = InMemoryUploadedFile(output, "ImageField", self.image.name, "image/jpeg",
+                                                  sys.getsizeof(output), None)
+            image.close()
 
         super(NewsBase, self).save(kwargs)
 

--- a/news/models.py
+++ b/news/models.py
@@ -1,6 +1,10 @@
+import sys
 import uuid
 from datetime import date, time
+from io import BytesIO
 
+from PIL import Image
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
@@ -69,6 +73,24 @@ class NewsBase(models.Model):
         default=False,
         verbose_name=_("MAKE internal"),
     )
+
+    def save(self, **kwargs):
+        """
+        Override of save, to change all JPEG images to have quality 90. This greatly reduces the size of JPEG images,
+        while resulting in non to very minuscule reduction in quality. In almost all cases, the possible reduction in
+        quality will not be visible to the naked eye.
+        """
+        image = Image.open(self.image)
+        if image.format == "JPEG":
+            output = BytesIO()
+            image.save(output, format="JPEG", quality=90)
+            output.seek(0)
+
+            self.image = InMemoryUploadedFile(output, "ImageField", self.image.name, "image/jpeg",
+                                              sys.getsizeof(output), None)
+        image.close()
+
+        super(NewsBase, self).save(kwargs)
 
     def __str__(self):
         return self.title.__str__()

--- a/news/models.py
+++ b/news/models.py
@@ -96,7 +96,7 @@ class NewsBase(models.Model):
             except IOError:
                 pass
 
-        super(NewsBase, self).save(kwargs)
+        super(NewsBase, self).save(**kwargs)
 
     def __str__(self):
         return self.title.__str__()


### PR DESCRIPTION
Lately I have been looking at improving the performance of the website. Through configuring Nginx caching policies and compression of text in transfer, I have been able to reduce the data transferred at first load of the homepage from 2.5 MB to 1.6 MB. Of these 1.6 MB, 1.1 MB are JPEG images. Some of these are quite small manually configured images hardcoded in HTML. These only account for about 0.1 MB of data. The remaining 1 MB of data are images from articles. Opening the articles page, you have to load an even larger amount of data.

This PR overrides the saving of articles and events, saving all JPEG images with a quality level of 90 (100 is the best). For images that are already below or at this quality level, this does not change anything. For images above this quality level, a large reduction in file size will be achieved. This will result in a slightly lower quality of these images, however going from quality 100 to quality 90 results in only minuscule changes in quality, that at worst are barely visible. For almost all images, the difference is not at all noticeable.

Taking the front page as an example, this would reduce the size of the page by between 0.7 MB and 0.8 MB. Effectively halving the amount of data transferred. The articles page would have an even larger reduction of transferred data.