### PR TITLE
Fix/news manager time

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -26,13 +26,13 @@ class TimePlaceManager(models.Manager):
 
     def future(self):
         return self.published().filter(
-            Q(start_date=timezone.localtime().date(), start_time__gt=timezone.localtime().time()) |
-            Q(start_date__gt=timezone.localtime().date()))
+            Q(end_date=timezone.localtime().date(), end_time__gt=timezone.localtime().time()) |
+            Q(end_date__gt=timezone.localtime().date()))
 
     def past(self):
         return self.published().filter(
-            Q(start_date=timezone.localtime().date(), start_time__lt=timezone.localtime().time()) |
-            Q(start_date__lt=timezone.localtime().date()))
+            Q(end_date=timezone.localtime().date(), end_time__lt=timezone.localtime().time()) |
+            Q(end_date__lt=timezone.localtime().date()))
 
 
 class NewsBase(models.Model):

--- a/news/models.py
+++ b/news/models.py
@@ -14,25 +14,25 @@ from web.multilingual.widgets import MultiLingualTextarea
 class ArticleManager(models.Manager):
     def published(self):
         return self.filter(hidden=False).filter(
-            Q(pub_date=timezone.now().date(), pub_time__lt=timezone.now().time()) |
-            Q(pub_date__lt=timezone.now().date()))
+            Q(pub_date=timezone.localtime().date(), pub_time__lt=timezone.localtime().time()) |
+            Q(pub_date__lt=timezone.localtime().date()))
 
 
 class TimePlaceManager(models.Manager):
     def published(self):
         return self.filter(hidden=False, event__hidden=False).filter(
-            Q(pub_date=timezone.now().date(), pub_time__lt=timezone.now().time()) |
-            Q(pub_date__lt=timezone.now().date()))
+            Q(pub_date=timezone.localtime().date(), pub_time__lt=timezone.localtime().time()) |
+            Q(pub_date__lt=timezone.localtime().date()))
 
     def future(self):
         return self.published().filter(
-            Q(start_date=timezone.now().date(), start_time__gt=timezone.now().time()) |
-            Q(start_date__gt=timezone.now().date()))
+            Q(start_date=timezone.localtime().date(), start_time__gt=timezone.localtime().time()) |
+            Q(start_date__gt=timezone.localtime().date()))
 
     def past(self):
         return self.published().filter(
-            Q(start_date=timezone.now().date(), start_time__lt=timezone.now().time()) |
-            Q(start_date__lt=timezone.now().date()))
+            Q(start_date=timezone.localtime().date(), start_time__lt=timezone.localtime().time()) |
+            Q(start_date__lt=timezone.localtime().date()))
 
 
 class NewsBase(models.Model):

--- a/news/tests.py
+++ b/news/tests.py
@@ -16,9 +16,9 @@ class ModelTestCase(TestCase):
                           hidden=TimePlace._meta.get_field("hidden").default):
         return TimePlace.objects.create(
             event=event,
-            pub_date=(timezone.now() + timedelta(days=pub_date_adjust_days)).date(),
-            start_date=timezone.now().date(),
-            start_time=(timezone.now() + timedelta(seconds=start_time_adjust_seconds)).time(),
+            pub_date=(timezone.localtime() + timedelta(days=pub_date_adjust_days)).date(),
+            end_date=timezone.localtime().date(),
+            end_time=(timezone.localtime() + timedelta(seconds=start_time_adjust_seconds)).time(),
             hidden=hidden,
         )
 
@@ -36,23 +36,23 @@ class ModelTestCase(TestCase):
     def test_article_manager(self):
         Article.objects.create(
             title='NOT PUBLISHED',
-            pub_date=(timezone.now() + timedelta(days=1)).date(),
-            pub_time=timezone.now().time()
+            pub_date=(timezone.localtime() + timedelta(days=1)).date(),
+            pub_time=timezone.localtime().time()
         )
         Article.objects.create(
             title='NOT PUBLISHED',
-            pub_date=timezone.now().date(),
-            pub_time=(timezone.now() + timedelta(seconds=1)).time()
+            pub_date=timezone.localtime().date(),
+            pub_time=(timezone.localtime() + timedelta(seconds=1)).time()
         )
         published1 = Article.objects.create(
             title='PUBLISHED',
-            pub_date=(timezone.now() - timedelta(days=1)).date(),
-            pub_time=timezone.now().time()
+            pub_date=(timezone.localtime() - timedelta(days=1)).date(),
+            pub_time=timezone.localtime().time()
         )
         published2 = Article.objects.create(
             title='PUBLISHED',
-            pub_date=timezone.now().date(),
-            pub_time=(timezone.now() - timedelta(seconds=1)).time()
+            pub_date=timezone.localtime().date(),
+            pub_time=(timezone.localtime() - timedelta(seconds=1)).time()
         )
         self.assertEqual(Article.objects.published().count(), 2)
         self.assertEqual(set(Article.objects.published()), {published1, published2})


### PR DESCRIPTION
Fixes filtering on published/past/future news and events.

Previously all times were in UTC, not local time as one would expect. This has led to some confusion when setting up events to be published at a specific time.

Also switched to using the end time to filter between past/future events. I think it makes more sense to "past" when it is actually over. This is especially useful for longer events where people meet up at a later time. The information will then be more easily available on the front page instead of hidden among the past events.