### PR TITLE
Fix incomplete hover text for the mazemap link

### DIFF
--- a/web/templates/web/footer.html
+++ b/web/templates/web/footer.html
@@ -9,7 +9,7 @@
             <div class="logo">
                 <img src="{% static "web/img/logo_allwhite.svg" %}">
             </div>
-            <a href="http://s.mazemap.com/2zleDaH" title={% trans "You can find us here!" %} target="_blank">{% trans "Makerverkstedet<br>Realfagbygget U1<br>7034 Trondheim" %} </a>
+            <a href="http://s.mazemap.com/2zleDaH" title="{% trans "You can find us here!" %}" target="_blank">{% trans "Makerverkstedet<br>Realfagbygget U1<br>7034 Trondheim" %} </a>
             <a href="http://s.mazemap.com/2zleDaH" target="blank"><i class="map marker alternate icon"></i></a>
         </div>
         <div class="ui social list">


### PR DESCRIPTION
Fixes the incomplete hover text on the mazemap link in the footer. The title content was not quoted and thus cut short.