### PR TITLE
Hide number of tickets when not needed

### DIFF
--- a/news/views.py
+++ b/news/views.py
@@ -236,6 +236,8 @@ class CreateTimePlaceView(PermissionRequiredMixin, CreateView):
         form = super().get_form(form_class)
         event = get_object_or_404(Event, pk=self.kwargs["event_pk"])
         form.fields["event"].initial = event.pk
+        if event.standalone:
+            del form.fields["number_of_tickets"]
         return form
 
     def get_success_url(self):


### PR DESCRIPTION
Hides the field for number of tickets on creation of timeplace objects when the event the timeplace object will belong to is a standalone event.