### PR TITLE
Fix for course registration error when card number field is just whitespace

### DIFF
--- a/card/models.py
+++ b/card/models.py
@@ -29,7 +29,7 @@ class CardNumberField(models.CharField):
     def get_prep_value(self, value):
         if isinstance(value, CardNumber):
             return value.number
-        elif isinstance(value, str):
+        elif isinstance(value, str) and len(value):
             return value.split()[-1]  # Remove possible EM prefix
         return value
 

--- a/card/models.py
+++ b/card/models.py
@@ -29,8 +29,11 @@ class CardNumberField(models.CharField):
     def get_prep_value(self, value):
         if isinstance(value, CardNumber):
             return value.number
-        elif isinstance(value, str) and len(value):
-            return value.split()[-1]  # Remove possible EM prefix
+        elif isinstance(value, str):
+            # Only try to remove the any EM prefix if the string is just whitespace
+            if value.strip():
+                return value.split()[-1]  # Remove possible EM prefix
+            return ""  # No need to include the whitespace
         return value
 
     def from_db_value(self, value, expression, connection):

--- a/card/tests.py
+++ b/card/tests.py
@@ -1,3 +1,28 @@
 from django.test import TestCase
 
-# Create your tests here.
+from card.models import CardNumberField, CardNumber
+
+
+class CardNumberModelFieldTest(TestCase):
+
+    def test_get_prep_value(self):
+        field = CardNumberField()
+        self.assertEqual("", field.get_prep_value(""), "The prep value of an empty string should be an empty string")
+        self.assertEqual("", field.get_prep_value("       "),
+                         "The prep value of a string of space should be an empty string")
+        self.assertEqual("", field.get_prep_value("\t\n \t\n   "),
+                         "The prep value of a string of whitespace should be an empty string")
+        self.assertEqual("1234567890", field.get_prep_value("1234567890"),
+                         "The prep value of a string of digits should be the same string")
+        self.assertEqual("1234567890", field.get_prep_value("EM 1234567890"),
+                         "The prep value of an EM number prefixed by EM should be the EM number without the prefix")
+        self.assertEqual("1234567890", field.get_prep_value(CardNumber("1234567890")),
+                         "The prep value of a CardNumber object should be its value")
+
+    def test_from_db_value(self):
+        field = CardNumberField()
+        value = field.from_db_value("1234567890", "", "")
+        self.assertEqual(CardNumber, type(value), "If the DB value is not empty it should be a CardNumber object")
+        self.assertEqual("1234567890", value.number, "The CardNumber objects should have the EM number as its number")
+
+        self.assertEqual(None, field.from_db_value("", "", ""), "An empty DB value should return None")


### PR DESCRIPTION
The course registration page errors when the card number field is empty or just spaces due to CardNumberField trying to split the string to remove any prefixes. This change checks if the string is just whitespace and in that case returns an empty string.

Also adds a set of simple tests to check the methods for the CardNumberField that convert between DB and python values.