### PR TITLE
Fix an issue with wrongly cropped article images on mobile

### DIFF
--- a/news/static/news/css/article.css
+++ b/news/static/news/css/article.css
@@ -39,7 +39,7 @@ a.place {
 .article > .container > img {
     object-fit: cover;
     width: 100%;
-    height: 400px;
+    max-height: 400px;
 }
 
 .publication_time {


### PR DESCRIPTION
Look at https://makentnu.no/news/event/44/ on mobile for an example of the problem. 