### PR TITLE
Fix overlap between event occurrences and the footer

### DIFF
--- a/news/static/news/css/article.css
+++ b/news/static/news/css/article.css
@@ -61,7 +61,8 @@ a.place {
 }
 
 .rail-content {
-    padding-top: 17px !important;
+    padding-top: 17px;
+    padding-bottom: 17px;
 }
 
 .event.article {

--- a/news/templates/news/event.html
+++ b/news/templates/news/event.html
@@ -241,3 +241,42 @@
     </div>
     <script>$('.ui.accordion').accordion('open', 0);</script>
 {% endblock event_accordion %}
+
+{% block scripts %}
+    {{ block.super }}
+    <script>
+        {% comment %}
+            Fomantic UI sticky does not adjust the height of the context element when the sticky part is longer. In the
+            cases where this needs to be done, we must make sure that the change is performed after Fomantic UI has
+            performed their own changes. Hopefully this will be fixed at some point in Fomantic UI, and we can remove
+            this stopgap solution. In most cases, the solution will not be needed, as the average number of occurrences
+            is low enough that the event content is heigher than the sticky part.
+        {% endcomment %}
+
+
+        $(document).ready(() => {
+            // Use a timeout of 50 to make sure that the Fomantic UI code is finished
+            setTimeout(() => {
+                let sticky = $(".ui.sticky.rail-content");
+                let context = $("#sticky");
+
+                function fixHeight() {
+                    // If the height of the sticky is greater than the context (the event content), then increase the
+                    // height of the event to be equal (that is the sticky is simply a single scroll).
+                    if (sticky.height() > context.height()) {
+                        context.height(`${sticky.height()}px`);
+                    }
+                }
+
+                // The sticky code resets the height on each resizing of the window. Thus the change must be performed
+                // each time the window is resized. To catch any other cases as well, we use the "onReposition" action.
+                sticky.sticky("setting", "onReposition", () => {
+                    // Use a timeout of 50 to make sure that the Fomantic UI code is finished
+                    setTimeout(fixHeight, 50);
+                });
+                fixHeight();
+            }, 50)
+
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
Fixes an issue where if there are a lot of future event occurrences, then the part of the event page showing these takes up more vertical space than the event content (image + title + text). This results in - due a _"problem"_ in Fomantic UI - some of the occurrences overlapping with the footer and/or just disappearing off the page. Especially, this results in weird interactions when scrolling (jumping up and down the page). 

While this problem is not a very common one, due to the events having enough content and few enough occurrences, it may occur in some cases. The purposed fix is not very nice, but there seems to be no better way of doing this, since the Fomantic UI code resizes the element each time the window is changed (resized, loaded, etc.) and thus one needs to use seemingly arbitrary timeouts to guarantee that one changes the height of the element containing the event content after the Fomantic UI code has been run.