### PR TITLE
Fixes Open Graph properties with Facebook

### DIFF
--- a/news/templates/news/article.html
+++ b/news/templates/news/article.html
@@ -8,6 +8,7 @@
 {% block og_title %}{{ article.title }}{% endblock og_title %}
 {% block og_image %}{{ article.image.url }}{% endblock og_image %}
 {% block og_description %}{{ article.clickbait }}{% endblock og_description %}
+{% block description %}{{ article.clickbait }}{% endblock description %}
 
 {% block head %}
     <link rel="stylesheet" type="text/css" href="{% static "news/css/article.css" %}">

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load i18n %}
+{% load uri_tags %}
 
 <!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
@@ -11,13 +12,13 @@
     <meta property="og:title" content="{% block og_title %}MAKE NTNU{% endblock og_title %}"/>
     <meta property="og:site_name" content="MAKE NTNU"/>
     <meta property="og:image"
-          content="http://makentnu.no{% block og_image %}{% static "web/img/make_thumb.png" %}{% endblock og_image %}"/>
+          content="{{ request.scheme }}://{{ request.get_host }}{% block og_image %}{% static "web/img/make_thumb.png" %}{% endblock og_image %}"/>
     <meta property="og:description"
           content="{% block og_description %}MAKE NTNU er en frivillig studentorganisasjon som jobber for et bedre miljø for prosjektutvikling, både i privat og undervisningssammenheng, for alle studenter på NTNU.{% endblock og_description %}"/>
     <meta property="description"
           content="{% block description %}MAKE NTNU er en frivillig studentorganisasjon som jobber for et bedre miljø for prosjektutvikling, både i privat og undervisningssammenheng, for alle studenter på NTNU.{% endblock description %}"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:url" content="http://makentnu.no/"/>
+    <meta property="og:url" content="{% get_absolute_uri_no_query request %}"/>
     <link rel="shortcut icon" type="image/png" href="{% static "web/img/favicon.png" %}"/>
     <meta name="theme-color" content="rgb(248, 200, 17)"/>
 

--- a/web/templatetags/uri_tags.py
+++ b/web/templatetags/uri_tags.py
@@ -1,0 +1,13 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag()
+def get_absolute_uri_no_query(request):
+    """
+    Returns the absolute URI of the request with no query parameters
+    :param request: The request
+    :return: The URI of the request page
+    """
+    return request.build_absolute_uri(request.path)


### PR DESCRIPTION
Fixes an issue where the `og:url` property was always set to `http://makentnu.no/`. Most sites work around this, where they just ignore the property when it is not the correct URL. Facebook, however, does not. Thus the preview data was always from the front-page. I have fixed this property to be the correct property for the given page (query parameters are removed, as per the specification).

Additionally, I have changed `og:image` to use utility in Django to get the schema and host (was set to `http://makentnu.no/` prior to the change).

The changes are live on [makentnu.dev](makentnu.dev) as of now, and an example article can be checked in Facebook's preview debugger [here](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fmakentnu.dev%2Fnews%2Farticle%2F37%2F).