### PR TITLE
Makerspace dropdown menu

### DIFF
--- a/web/static/web/css/header.css
+++ b/web/static/web/css/header.css
@@ -25,7 +25,7 @@
 }
 
 #header .item:hover > .text {
-    color: #FFF;
+    color: #eee;
 }
 
 #header div.logo-centering {
@@ -66,7 +66,8 @@
 
 #nav > .item:hover,
 #side-nav > .item:hover,
-#nav-user-dropdown.active {
+#nav-user-dropdown.active,
+#makerspace-dropdown.active {
     /* Disables property from Fomantic UI */
     background-color: transparent;
 }
@@ -128,7 +129,9 @@
     margin-right: 0;
 }
 
-#nav-user-dropdown .menu {
+
+#nav-user-dropdown .menu,
+#makerspace-dropdown .menu {
     background-color: rgb(34, 43, 52);
     border-radius: 7px;
     border: 2px solid rgb(220, 221, 222);
@@ -140,7 +143,8 @@
     align-self: auto;
 }
 
-#nav-user-dropdown .menu > .item:hover {
+#nav-user-dropdown .menu > .item:hover,
+#makerspace-dropdown .menu > .item:hover {
     background-color: rgba(255, 255, 255, 0.08) !important; /* Overrides Fomantic UI */
 }
 

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -36,10 +36,19 @@
             <div class="text">{% trans "Reservations" %}</div>
             <div class="make_bg_blue bubble-background"></div>
         </a>
-        <a class="item" href="{% url 'makerspace' %}">
+    
+        <nav id="makerspace-dropdown" class="ui dropdown item" >
             <div class="text">{% trans "Makerverkstedet" %}</div>
-            <div class="make_bg_turquoise bubble-background"></div>
-        </a>
+            <i class="dropdown icon text" tabindex{# For disabling focus on click #}></i>
+            <div class="make_bg_turquoise bubble-background"></div> 
+
+            <nav class="menu transition" aria-label="User">
+                    <a class="item" href="{% url 'adminpanel' %}">
+                        <div class="text">{% trans "Administration" %}</div>
+                    </a>
+            
+            </nav>
+        </nav>
         <a class="item" href="{% url 'about' %}">
             <div class="text">{% trans "About us" %}</div>
             <div class="make_bg_yellow bubble-background"></div>
@@ -130,6 +139,8 @@
 
 <script>
     $('#nav-user-dropdown').dropdown({action: "nothing"});
+    $('#makerspace-dropdown').dropdown({action: "nothing"});
+
 
     $(".lang-link").click(function (event) {
         event.preventDefault();

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -43,8 +43,11 @@
             <div class="make_bg_turquoise bubble-background"></div> 
 
             <nav class="menu transition" aria-label="User">
-                    <a class="item" href="{% url 'adminpanel' %}">
-                        <div class="text">{% trans "Administration" %}</div>
+                    <a class="item" href="{% url 'makerspace' %}">
+                        <div class="text">{% trans "Makerverkstedet" %}</div>
+                    </a>
+                    <a class="item" href="{% url 'rules' %}">
+                        <div class="text">{% trans "Rules" %}</div>
                     </a>
             
             </nav>


### PR DESCRIPTION
Added a [dropdown menu](https://trello.com/c/15VSMIhS/200-add-makerverkstedet-dropdown-menu) to the makerspace header for viewing different pages such as "About Makerspace", ["Rules"](https://trello.com/c/FQqUdiPu/151-rules-for-using-makerverkstedet-needs-to-be-more-visible-in-makerverkstedet-and-updated), "Equipment list" etc. 
