### PR TITLE
Move events before articles

### DIFF
--- a/web/static/web/css/header.css
+++ b/web/static/web/css/header.css
@@ -6,7 +6,7 @@
 
     --burger-margin: 1em;
 
-    --header-height: 120px;
+    --header-height: 100px;
 
     /* nav */
     --nav-space-between: 2em;

--- a/web/static/web/css/index.css
+++ b/web/static/web/css/index.css
@@ -13,8 +13,8 @@
     z-index: -10;
     width: 100%;
     height: calc(50vh - 120px);
-    min-height: 150px;
-    max-height: 300px;
+    min-height: 50px;
+    max-height: 170px;
 }
 
 .topimg {

--- a/web/static/web/css/index.css
+++ b/web/static/web/css/index.css
@@ -13,8 +13,8 @@
     z-index: -10;
     width: 100%;
     height: calc(50vh - 120px);
-    min-height: 50px;
-    max-height: 170px;
+    min-height: 150px;
+    max-height: 200px;
 }
 
 .topimg {

--- a/web/static/web/css/index.css
+++ b/web/static/web/css/index.css
@@ -120,7 +120,7 @@
     display: grid;
     grid-template-columns: 1fr 10fr 10fr 1fr;
     grid-auto-flow: dense;
-    margin: 80px 0;
+    margin: 50px 0;
 }
 
 .articles .article-img {
@@ -177,6 +177,8 @@
 @media screen and (max-width: 992px) {
     .articles {
         grid-template-columns: 1fr 20fr 1fr;
+        margin-top: 20px;
+        margin-bottom: 0;
     }
 
     .articles .article-text,

--- a/web/templates/web/index.html
+++ b/web/templates/web/index.html
@@ -27,31 +27,7 @@
         <img class="topimg small" src="{% static "web/img/topimg_small.jpg" %}">
         <img class="toplogo" src="{% static "web/img/logo_black.svg" %}">
     </div>
-    <div class="ui container">
-        <div class="articles">
-            {% for article in articles %}
-                {% thumbnail article.image "600" crop="center" as im %}
-                    <img class="article-img clickable {% cycle 'float-right' 'float-left' %}
-			    {% if forloop.first %}article-first{% endif %}
-			    {% if forloop.last %}article-last{% endif %}"
-                         src="{{ im.url }}" href="{% url 'article' article.id %}"
-                         {% if article.contain %}style="object-fit: contain;" {% endif %}>
-                {% endthumbnail %}
-                <div class="article-text {% cycle 'float-left' 'float-right' %}
-			    {% if forloop.first %}article-first{% endif %}
-			    {% if forloop.last %}article-last{% endif %}">
-                    <img class="txtborder tl" src="{% static "web/img/top_left.svg" %}">
-                    <img class="txtborder tr" src="{% static "web/img/top_right.svg" %}">
-                    <img class="txtborder bl" src="{% static "web/img/bottom_left.svg" %}">
-                    <img class="txtborder br" src="{% static "web/img/bottom_right.svg" %}">
-                    <div>
-                        <h2><a href="{% url 'article' article.id %}">{{ article.title }}</a></h2>
-                        <p>{{ article.clickbait }}</p>
-                    </div>
-                </div>
-            {% endfor %}
-        </div>
-    </div>
+
     <div style="height: 100px;"></div>
     <div class="ui container">
         <div class="ui items events">
@@ -83,6 +59,33 @@
             {% endfor %}
         </div>
     </div>
+    
+    <div class="ui container">
+        <div class="articles">
+            {% for article in articles %}
+                {% thumbnail article.image "600" crop="center" as im %}
+                    <img class="article-img clickable {% cycle 'float-right' 'float-left' %}
+			    {% if forloop.first %}article-first{% endif %}
+			    {% if forloop.last %}article-last{% endif %}"
+                         src="{{ im.url }}" href="{% url 'article' article.id %}"
+                         {% if article.contain %}style="object-fit: contain;" {% endif %}>
+                {% endthumbnail %}
+                <div class="article-text {% cycle 'float-left' 'float-right' %}
+			    {% if forloop.first %}article-first{% endif %}
+			    {% if forloop.last %}article-last{% endif %}">
+                    <img class="txtborder tl" src="{% static "web/img/top_left.svg" %}">
+                    <img class="txtborder tr" src="{% static "web/img/top_right.svg" %}">
+                    <img class="txtborder bl" src="{% static "web/img/bottom_left.svg" %}">
+                    <img class="txtborder br" src="{% static "web/img/bottom_right.svg" %}">
+                    <div>
+                        <h2><a href="{% url 'article' article.id %}">{{ article.title }}</a></h2>
+                        <p>{{ article.clickbait }}</p>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+    
     <script>
         $('.clickable').click(function () {
             window.location.href = $(this).attr('href');

--- a/web/templates/web/index.html
+++ b/web/templates/web/index.html
@@ -28,7 +28,7 @@
         <img class="toplogo" src="{% static "web/img/logo_black.svg" %}">
     </div>
 
-    <div style="height: 100px;"></div>
+    <div style="height: 50px;"></div>
     <div class="ui container">
         <div class="ui items events">
             {% for event in events %}

--- a/web/templates/web/index.html
+++ b/web/templates/web/index.html
@@ -92,5 +92,4 @@
         });
         $('.parallax-window').parallax({'speed': 0.5});
     </script>
-    <div style="height: 100px;"></div>
 {% endblock body %}

--- a/web/views.py
+++ b/web/views.py
@@ -17,7 +17,7 @@ class IndexView(TemplateView):
 
         context.update({
             'articles': Article.objects.published().filter(featured=True)[:4],
-            'events': events[:4],
+            'events': events[:2],
         })
         return context
 

--- a/web/views.py
+++ b/web/views.py
@@ -17,7 +17,7 @@ class IndexView(TemplateView):
 
         context.update({
             'articles': Article.objects.published().filter(featured=True)[:4],
-            'events': events[:2],
+            'events': events[:4],
         })
         return context
 


### PR DESCRIPTION
This PR moves events so they appear before articles on the front page. It also reduces the height of the MAKENTNU banner. 