### PR TITLE
Configure logging and add logging where appropriate

### DIFF
--- a/dataporten/views.py
+++ b/dataporten/views.py
@@ -28,7 +28,7 @@ def login_wrapper(request, backend, *args, **kwargs):
     try:
         response = complete(request, backend, *args, **kwargs)
     except Exception as e:
-        logging.exception("Authentication through Dataporten failed.", exc_info=e)
+        logging.getLogger('django.request').exception("Authentication through Dataporten failed.", exc_info=e)
         return HttpResponseForbidden()
 
     user = request.user

--- a/mail/email.py
+++ b/mail/email.py
@@ -42,8 +42,9 @@ class EmailConsumer(SyncConsumer):
         try:
             msg.send(fail_silently=False)
         except smtplib.SMTPException as e:
-            logging.error(
-                f"Failed sending plain text email from {message['from']} to {message['to']} with exception: {e}")
+            logging.getLogger('django.request').exception(
+                f"Failed sending plain text email from {message['from']} to {message['to']}.", exc_info=e,
+            )
 
     def send_html(self, message):
         """
@@ -55,7 +56,9 @@ class EmailConsumer(SyncConsumer):
         try:
             msg.send(fail_silently=False)
         except smtplib.SMTPException as e:
-            logging.error(f"Failed sending HTML email from {message['from']} to {message['to']} with exception: {e}")
+            logging.getLogger('django.request').exception(
+                f"Failed sending HTML email from {message['from']} to {message['to']}.", exc_info=e,
+            )
 
     def create_message(self, message):
         """

--- a/make_queue/views/reservation/reservation.py
+++ b/make_queue/views/reservation/reservation.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABCMeta
 from math import ceil
 
@@ -131,8 +132,8 @@ class ReservationCreateOrChangeView(TemplateView):
             form = ReservationForm(request.POST)
             if form.is_valid():
                 return self.form_valid(form, **kwargs)
-        except Exception:
-            pass
+        except Exception as e:
+            logging.getLogger('django.request').exception(e)
         return self.get(request, **kwargs)
 
 

--- a/news/models.py
+++ b/news/models.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import uuid
 from io import BytesIO
@@ -83,8 +84,8 @@ class NewsBase(models.Model):
                     self.image = InMemoryUploadedFile(output, "ImageField", self.image.name, "image/jpeg",
                                                       sys.getsizeof(output), None)
                 # Should not close image, as Django uses the image and closes it by default
-            except IOError:
-                pass
+            except IOError as e:
+                logging.getLogger('django.request').exception(e)
 
         super(NewsBase, self).save(**kwargs)
 

--- a/web/multilingual/data_structures.py
+++ b/web/multilingual/data_structures.py
@@ -16,18 +16,27 @@ class MultiLingualTextStructure:
     def __init__(self, linear_content, use_default_for_empty):
         self.use_default_for_empty = use_default_for_empty
         self.languages = {language: "" for language in self.supported_languages}
+        self.set_content_for_languages(linear_content)
+
+    def set_content_for_languages(self, linear_content):
+        if not isinstance(linear_content, str):
+            logging.getLogger('django.request').exception(
+                f"Cannot set content to '{linear_content}'; {type(str)} expected, but received {type(linear_content)}"
+            )
+            return
+        if not linear_content:
+            return
         try:
-            # Try to decode the data as JSON
-            for language, value in json.loads(linear_content).items():
-                self.languages[language] = value
+            json_dict = json.loads(linear_content)
         except JSONDecodeError as e:
             # If for some reason (i.e. old or corrupt data) the content given is not JSON,
             # use it as content for the default language.
             self.languages[settings.LANGUAGE_CODE] = linear_content
             logging.getLogger('django.request').exception(e)
-        except TypeError as e:
-            # If none or other incompatible type is passed
-            logging.getLogger('django.request').exception(e)
+            return
+
+        for language, value in json_dict.items():
+            self.languages[language] = value
 
     def __str__(self):
         """

--- a/web/multilingual/data_structures.py
+++ b/web/multilingual/data_structures.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from json import JSONDecodeError
 
 from django.utils.translation import get_language
@@ -19,13 +20,14 @@ class MultiLingualTextStructure:
             # Try to decode the data as JSON
             for language, value in json.loads(linear_content).items():
                 self.languages[language] = value
-        except JSONDecodeError:
+        except JSONDecodeError as e:
             # If for some reason (i.e. old or corrupt data) the content given is not JSON,
             # use it as content for the default language.
             self.languages[settings.LANGUAGE_CODE] = linear_content
-        except TypeError:
+            logging.getLogger('django.request').exception(e)
+        except TypeError as e:
             # If none or other incompatible type is passed
-            pass
+            logging.getLogger('django.request').exception(e)
 
     def __str__(self):
         """

--- a/web/multilingual/form.py
+++ b/web/multilingual/form.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 from ckeditor.fields import RichTextFormField
 from ckeditor_uploader.fields import RichTextUploadingFormField
@@ -25,8 +26,8 @@ class MultiLingualFormField(forms.MultiValueField):
             # Non required fields may not have enough values
             try:
                 structure[language] = data_list[index]
-            except IndexError:
-                pass
+            except IndexError as e:
+                logging.getLogger('django.request').exception(e)
         return structure
 
     def __init__(self, *args, **kwargs):

--- a/web/settings.py
+++ b/web/settings.py
@@ -242,3 +242,35 @@ CKEDITOR_CONFIGS = {
 # Phonenumbers
 PHONENUMBER_DEFAULT_REGION = 'NO'
 PHONENUMBER_DEFAULT_FORMAT = 'NATIONAL'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
+        },
+    },
+    'handlers': {
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'filters': ['require_debug_true'],
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+    },
+}

--- a/web/settings.py
+++ b/web/settings.py
@@ -1,4 +1,11 @@
+import logging
+import sys
 from pathlib import Path
+
+# Disable logging when testing
+if 'test' in sys.argv:
+    # Disable calls with severity level equal to or less than `CRITICAL` (i.e. everything)
+    logging.disable(logging.CRITICAL)
 
 # Default values
 DATABASE = 'sqlite'


### PR DESCRIPTION
This PR facilitates logging exceptions - which simultaneously sends an email to the admins - through calling e.g. `logging.getLogger('django.request').exception(e)`.

This also facilitates printing all database queries to the console, which can aid in figuring out the number of times the database is queried for a request. Enabling this behavior can be done by e.g. adding the following to the bottom of `settings.py`:
```Python
LOGGING['loggers']['django.db.backends'] = {
    'level': 'DEBUG',
    'handlers': ['console'],
}
```

---

*The logging settings are based on [the default Django settings](https://github.com/django/django/blob/7b31ba541f1dfb3a8e782b1319c25a24f9d86f8a/django/utils/log.py#L17-L63).*