### PR TITLE
Run apt update before installing system dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          sudo apt install python-dev libldap2-dev libsasl2-dev libssl-dev
+          sudo apt update && sudo apt install python-dev libldap2-dev libsasl2-dev libssl-dev
 
       - name: Install Python Dependencies
         run: |


### PR DESCRIPTION
Currently the workflow fails when installing system packages because the package index has been changed. This fixes the workflow by running `apt update` before installing system packages.