### PR TITLE
Fixes for course registration search functionality

### DIFF
--- a/make_queue/static/make_queue/css/general.css
+++ b/make_queue/static/make_queue/css/general.css
@@ -40,6 +40,13 @@
     display: none !important;
 }
 
+/* Tables on mobile have very specific rules that use !important */
+@media only screen and (max-width: 767px) {
+    .ui.table > tbody > tr.make_hidden {
+        display: none !important;
+    }
+}
+
 .make_non_visible {
     visibility: hidden !important;
 }

--- a/make_queue/static/make_queue/js/course_registration_list.js
+++ b/make_queue/static/make_queue/js/course_registration_list.js
@@ -130,6 +130,19 @@ $("#status_set").parent().dropdown({
 $("#search").on("input", function () {
     state.search_value = $(this).val().toLowerCase();
     filter();
+}).on("keydown", function (event) {
+    // We do not want to trigger form submit on pressing the enter key. The
+    // default functionality is search, and pressing the enter key should
+    // emulate that.
+    if (event.key === "Enter") {
+        // Loose focus of the input field. This is important for mobile as
+        // hitting enter is equivalent to hitting "search".
+        $(this).blur();
+
+        // Prevent form submission
+        event.preventDefault();
+        return false;
+    }
 });
 
 // Each table header element can be clicked to change the sorting of the table

--- a/make_queue/templates/make_queue/course/course_registration_list.html
+++ b/make_queue/templates/make_queue/course/course_registration_list.html
@@ -2,14 +2,11 @@
 {% load i18n %}
 {% load static %}
 
+{% block head %}
+    <link rel="stylesheet" href="{% static "make_queue/css/general.css" %}">
+{% endblock head %}
+
 {% block body %}
-
-    <style>
-        .make_hidden {
-            display: none;
-        }
-    </style>
-
     <div class="ui container">
         <h1>
             {% trans "Course registrations" %}


### PR DESCRIPTION
Fixes two issues:

- Properly hides users that do not match search on mobile
- Hitting enter on the keyboard or equivalently the "search" button on a mobile keyboard no longer triggers a download of a spreadsheet of the selected users. Instead, it takes focus away from the search field, i.e., as if the user finished their search. This should be a natural reaction from hitting enter/"search" when searching. For the spreadsheet, the download button must be used, as would be expected.