### PR TITLE
Fix event layout bug in event list

### DIFF
--- a/news/templates/news/event_list.html
+++ b/news/templates/news/event_list.html
@@ -16,7 +16,7 @@
     {% if future %}
         <div class="ui items events" style="margin: 80px 0;">
             {% for event in future %}
-                <div class="item">
+                <div class="event item">
                     <div class="ui small image">
                         <p class="ui yellow make-bg-yellow ribbon label">
                             {{ event.first_occurrence.start_time|year_wise_short_date }}
@@ -69,7 +69,7 @@
     {% if past %}
         <div class="ui items events" style="margin: 80px 0;">
             {% for event in past %}
-                <div class="item">
+                <div class="event item">
                     <div class="ui small image">
                         <p class="ui yellow make-bg-yellow ribbon label">
                             {{ event.last_occurrence.start_time|year_wise_short_date }}


### PR DESCRIPTION
This was caused by the changes in #379, in which `index.css` was changed. That stylesheet was also used by `event_list.html` and `article_list.html` (despite the stylesheet's name), which were accidentally not updated.