### PR TITLE
Make dirtied forms prevent user from leaving

### DIFF
--- a/docs/templates/docs/documentation_page_detail.html
+++ b/docs/templates/docs/documentation_page_detail.html
@@ -71,7 +71,7 @@
     </div>
 
     {% if form and old and perms.docs.change_page %}
-        <form id="change-version-form" class="hidden form" method="POST"
+        <form id="change-version-form" class="dont-prevent-leaving hidden form" method="POST"
               action="{% url 'change_page_version' pk=page %}">
             {% csrf_token %}
             {{ form }}

--- a/docs/templates/docs/header.html
+++ b/docs/templates/docs/header.html
@@ -6,7 +6,7 @@
 
 <header id="header">
     <div id="page-search">
-        <form id="search-form" method="GET" action="{% url 'search_pages' %}">
+        <form id="search-form" class="dont-prevent-leaving" method="GET" action="{% url 'search_pages' %}">
             <div class="ui icon input">
                 <input id="query" type="text" name="query" placeholder="{% trans "Search" %}"/>
                 <i id="search" class="search link icon"></i>

--- a/docs/templates/docs/search.html
+++ b/docs/templates/docs/search.html
@@ -7,7 +7,7 @@
     <div class="ui container">
         <h1>{% trans "Search" %}</h1>
 
-        <form class="ui form" method="GET">
+        <form class="dont-prevent-leaving ui form" method="GET">
             <div class="ui field">
                 <div class="ui icon input">
                     <input type="text" name="query" placeholder="{% trans "Search" %}" value="{{ query }}"/>
@@ -41,7 +41,7 @@
             {% trans "There are no documents for that search. Try searching for something else." %}
         {% endif %}
 
-        <form id="page-form" method="GET">
+        <form id="page-form" class="dont-prevent-leaving" method="GET">
             <input type="hidden" name="query" value="{{ query }}"/>
             <input id="page-form-page-input" type="hidden" name="page" value="{{ page }}"/>
         </form>

--- a/internal/templates/internal/member_list.html
+++ b/internal/templates/internal/member_list.html
@@ -24,7 +24,7 @@
             {% endif %}
         </h1>
 
-        <form class="ui form">
+        <form class="dont-prevent-leaving ui form">
             <div id="filter-fields" class="ui fields">
                 <div class="ui six wide field">
                     <input id="search" type="text" name="search-text" placeholder="{% trans "Search name and username" %}"/>
@@ -298,7 +298,7 @@
             <h4 class="ui horizontal divider header">
                 <i class="ui make-col-yellow key icon"></i>{% trans "System accesses" %}
             </h4>
-            <form id="edit-system-access-form" method="POST">
+            <form id="edit-system-access-form" class="dont-prevent-leaving" method="POST">
                 {% csrf_token %}
                 <table class="ui very basic unstackable celled table">
                     <tbody id="member-system-accesses">
@@ -311,7 +311,7 @@
                 <h4 class="ui horizontal divider header">
                     <i class="ui wrench make-col-yellow icon"></i>{% trans "Actions" %}
                 </h4>
-                <form id="edit-member-status-form" class="member-action-buttons" method="POST">
+                <form id="edit-member-status-form" class="dont-prevent-leaving member-action-buttons" method="POST">
                     {% csrf_token %}
                     <a id="member-setQuitUrl-button" class="ui red button">
                         {% trans "Set member as quit" %}

--- a/make_queue/static/make_queue/js/calendar.js
+++ b/make_queue/static/make_queue/js/calendar.js
@@ -110,7 +110,7 @@ ReservationCalendar.prototype.selectionPopupContent = function () {
     $popupContent.find(".button").on("mousedown touchstart", () => {
         // Create and submit a hidden form to create a new reservation
         const $form = $(
-            `<form class="display-none" method="POST" action="${LANG_PREFIX}/reservation/create/${calendar.machine}/">`,
+            `<form class="dont-prevent-leaving display-none" method="POST" action="${LANG_PREFIX}/reservation/create/${calendar.machine}/">`,
         ).appendTo($popupContent);
         $("input[name=csrfmiddlewaretoken]").clone().appendTo($form);
         $('<input name="start_time"/>').val(startTime.djangoFormat()).appendTo($form);

--- a/make_queue/templates/make_queue/course/course_registration_list.html
+++ b/make_queue/templates/make_queue/course/course_registration_list.html
@@ -18,7 +18,7 @@
             </a>
         </h1>
 
-        <form id="download-users" class="ui form" method="POST" action="{% url 'download_course_registrations' %}">
+        <form id="download-users" class="dont-prevent-leaving ui form" method="POST" action="{% url 'download_course_registrations' %}">
             {% csrf_token %}
             <div class="ui fields">
                 <div class="ui six wide field">
@@ -192,7 +192,7 @@
             {% trans "Set status of users to" %} &quot;<i><span id="set-status-text"></span></i>&quot;
         </div>
 
-        <form method="POST" action="{% url 'bulk_status_update' %}">
+        <form class="dont-prevent-leaving" method="POST" action="{% url 'bulk_status_update' %}">
             {% csrf_token %}
             <input id="status" type="hidden" value="" name="status"/>
         </form>

--- a/make_queue/templates/make_queue/find_free_slot.html
+++ b/make_queue/templates/make_queue/find_free_slot.html
@@ -16,7 +16,7 @@
 
     <div class="ui container">
         <h1>{% trans "Find free reservation slots" %}</h1>
-        <form class="ui form" method="POST">
+        <form class="dont-prevent-leaving ui form" method="POST">
             {% csrf_token %}
             <div class="ui fields">
                 <div class="ui six wide field">

--- a/web/static/lib/jquery/jquery.dirty.js
+++ b/web/static/lib/jquery/jquery.dirty.js
@@ -1,0 +1,308 @@
+/*
+ * Dirty
+ * jquery plugin to detect when a form is modified
+ * (c) 2016 Simon Taite - https://github.com/simon-reynolds/jquery.dirty
+ * originally based on jquery.dirrty by Ruben Torres - https://github.com/rubentd/dirrty
+ * Released under the MIT license
+ */
+
+(function($) {
+
+    //Save dirty instances
+    var singleDs = [];
+    var dirty = "dirty";
+    var clean = "clean";
+    var dataInitialValue = "dirtyInitialValue";
+    var dataIsDirty = "isDirty";
+
+    var getSingleton = function(id) {
+        var result;
+        singleDs.forEach(function(e) {
+            if (e.id === id) {
+                result = e;
+            }
+        });
+        return result;
+    };
+
+    var setSubmitEvents = function(d) {
+        d.form.on("submit", function() {
+            d.submitting = true;
+        });
+
+        if (d.options.preventLeaving) {
+            $(window).on("beforeunload", function(event) {
+                if (d.isDirty && !d.submitting) {
+                    event.preventDefault();
+                    return d.options.leavingMessage;
+                }
+            });
+        }
+    };
+
+    var setNamespacedEvents = function(d) {
+
+        d.form.find("input, select, textarea").on("change.dirty click.dirty keyup.dirty keydown.dirty blur.dirty", function(e) {
+            d.checkValues(e);
+        });
+
+        d.form.on("dirty", function() {
+            d.options.onDirty();
+        });
+
+        d.form.on("clean", function() {
+            d.options.onClean();
+        });
+    };
+
+    var clearNamespacedEvents = function(d) {
+        d.form.find("input, select, textarea").off("change.dirty click.dirty keyup.dirty keydown.dirty blur.dirty");
+
+        d.form.off("dirty");
+
+        d.form.off("clean");
+    };
+
+    var Dirty = function(form, options) {
+        this.form = form;
+        this.isDirty = false;
+        this.options = options;
+        this.history = [clean, clean]; //Keep track of last statuses
+        this.id = $(form).attr("id");
+        singleDs.push(this);
+    };
+
+    Dirty.prototype = {
+        init: function() {
+            this.saveInitialValues();
+            this.setEvents();
+        },
+
+        isRadioOrCheckbox: function(el){
+            return $(el).is(":radio, :checkbox");
+        },
+
+        isFileInput: function(el){
+            return $(el).is(":file")
+        },
+
+        saveInitialValues: function() {
+            var d = this;
+            this.form.find("input, select, textarea").each(function(_, e) {
+
+                var isRadioOrCheckbox = d.isRadioOrCheckbox(e);
+                var isFile = d.isFileInput(e);
+
+                if (isRadioOrCheckbox) {
+                    var isChecked = $(e).is(":checked") ? "checked" : "unchecked";
+                    $(e).data(dataInitialValue, isChecked);
+                } else if(isFile){
+                    $(e).data(dataInitialValue, JSON.stringify(e.files))
+                } else {
+                    $(e).data(dataInitialValue, $(e).val() || '');
+                }
+            });
+        },
+
+        refreshEvents: function () {
+            var d = this;
+            clearNamespacedEvents(d);
+            setNamespacedEvents(d);
+        },
+
+        showDirtyFields: function() {
+            var d = this;
+
+            return d.form.find("input, select, textarea").filter(function(_, e){
+                return $(e).data("isDirty");
+            });
+        },
+
+        setEvents: function() {
+            var d = this;
+
+            setSubmitEvents(d);
+            setNamespacedEvents(d);
+        },
+
+        isFieldDirty: function($field) {
+            var initialValue = $field.data(dataInitialValue);
+             // Explicitly check for null/undefined here as value may be `false`, so ($field.data(dataInitialValue) || '') would not work
+            if (initialValue == null) { initialValue = ''; }
+            var currentValue = $field.val();
+            if (currentValue == null) { currentValue = ''; }
+
+            // Boolean values can be encoded as "true/false" or "True/False" depending on underlying frameworks so we need a case insensitive comparison
+            var boolRegex = /^(true|false)$/i;
+            var isBoolValue = boolRegex.test(initialValue) && boolRegex.test(currentValue);
+            if (isBoolValue) {
+                var regex = new RegExp("^" + initialValue + "$", "i");
+                return !regex.test(currentValue);
+            }
+
+            return currentValue !== initialValue;
+        },
+
+        isFileInputDirty: function($field) {
+            var initialValue = $field.data(dataInitialValue);
+
+            var plainField = $field[0];
+            var currentValue = JSON.stringify(plainField.files);
+
+            return currentValue !== initialValue;
+        },
+
+        isCheckboxDirty: function($field) {
+            var initialValue = $field.data(dataInitialValue);
+            var currentValue = $field.is(":checked") ? "checked" : "unchecked";
+
+            return initialValue !== currentValue;
+        },
+
+        checkValues: function(e) {
+            var d = this;
+            var formIsDirty = false;
+
+            this.form.find("input, select, textarea").each(function(_, el) {
+                var isRadioOrCheckbox = d.isRadioOrCheckbox(el);
+                var isFile = d.isFileInput(el);
+                var $el = $(el);
+
+                var thisIsDirty;
+                if (isRadioOrCheckbox) {
+                    thisIsDirty = d.isCheckboxDirty($el);
+                } else if (isFile) {
+                    thisIsDirty = d.isFileInputDirty($el);
+                } else {
+                    thisIsDirty = d.isFieldDirty($el);
+                }
+
+                $el.data(dataIsDirty, thisIsDirty);
+
+                formIsDirty |= thisIsDirty;
+            });
+
+            if (formIsDirty) {
+                d.setDirty();
+            } else {
+                d.setClean();
+            }
+        },
+
+        setDirty: function() {
+            this.isDirty = true;
+            this.history[0] = this.history[1];
+            this.history[1] = dirty;
+
+            if (this.options.fireEventsOnEachChange || this.wasJustClean()) {
+                this.form.trigger("dirty");
+            }
+        },
+
+        setClean: function() {
+            this.isDirty = false;
+            this.history[0] = this.history[1];
+            this.history[1] = clean;
+
+            if (this.options.fireEventsOnEachChange || this.wasJustDirty()) {
+                this.form.trigger("clean");
+            }
+        },
+
+        //Lets me know if the previous status of the form was dirty
+        wasJustDirty: function() {
+            return (this.history[0] === dirty);
+        },
+
+        //Lets me know if the previous status of the form was clean
+        wasJustClean: function() {
+            return (this.history[0] === clean);
+        },
+
+        setAsClean: function(){
+            this.saveInitialValues();
+            this.setClean();
+        },
+
+        setAsDirty: function(){
+            this.saveInitialValues();
+            this.setDirty();
+        },
+
+        resetForm: function(){
+            var d = this;
+            this.form.find("input, select, textarea").each(function(_, e) {
+
+                var $e = $(e);
+                var isRadioOrCheckbox = d.isRadioOrCheckbox(e);
+                var isFile = d.isFileInput(e);
+
+                if (isRadioOrCheckbox) {
+                    var initialCheckedState = $e.data(dataInitialValue);
+                    var isChecked = initialCheckedState === "checked";
+
+                    $e.prop("checked", isChecked);
+                } if(isFile) {
+                    e.value = "";
+                    $(e).data(dataInitialValue, JSON.stringify(e.files))
+
+                } else {
+                    var value = $e.data(dataInitialValue);
+                    $e.val(value);
+                }
+            });
+
+            this.checkValues();
+        }
+    };
+
+    $.fn.dirty = function(options) {
+
+        if (typeof options === "string" && /^(isDirty|isClean|refreshEvents|resetForm|setAsClean|setAsDirty|showDirtyFields)$/i.test(options)) {
+            //Check if we have an instance of dirty for this form
+            // TODO: check if this is DOM or jQuery object
+            var d = getSingleton($(this).attr("id"));
+
+            if (!d) {
+                d = new Dirty($(this), options);
+                d.init();
+            }
+            var optionsLowerCase = options.toLowerCase();
+
+            switch (optionsLowerCase) {
+            case "isclean":
+                return !d.isDirty;
+            case "isdirty":
+                return d.isDirty;
+            case "refreshevents":
+                d.refreshEvents();
+            case "resetform":
+                d.resetForm();
+            case "setasclean":
+                return d.setAsClean();
+            case "setasdirty":
+                return d.setAsDirty();
+            case "showdirtyfields":
+                return d.showDirtyFields();
+            }
+
+        } else if (typeof options === "object" || !options) {
+
+            return this.each(function(_, e) {
+                options = $.extend({}, $.fn.dirty.defaults, options);
+                var dirty = new Dirty($(e), options);
+                dirty.init();
+            });
+
+        }
+    };
+
+    $.fn.dirty.defaults = {
+        preventLeaving: false,
+        leavingMessage: "There are unsaved changes on this page which will be discarded if you continue.",
+        onDirty: $.noop, //This function is fired when the form gets dirty
+        onClean: $.noop, //This funciton is fired when the form gets clean again
+        fireEventsOnEachChange: false, // Fire onDirty/onClean on each modification of the form
+    };
+
+})(jQuery);

--- a/web/static/web/js/common_utils.js
+++ b/web/static/web/js/common_utils.js
@@ -5,3 +5,9 @@ $(".message .close").click(function () {
 });
 
 $("span[data-content], .explanation-popup").popup();
+
+// Only forms that have not opted out (using the `dont-prevent-leaving` class),
+// and that have a `method` attribute that is not `GET` (case-insensitive) - as those forms shouldn't contain data that is saved in the backend
+$("form:not(.dont-prevent-leaving)[method]:not([method=GET])").dirty({
+    preventLeaving: true,
+});

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -32,6 +32,7 @@
     <link rel="stylesheet" href="{% static 'web/css/style.css' %}"/>
     <script src="{% host_url 'javascript_catalog' host 'main' %}"></script>
     <script src="{% static 'lib/jquery/jquery.min.js' %}"></script>
+    <script src="{% static 'lib/jquery/jquery.dirty.js' %}"></script>
     <script src="{% static 'lib/fomantic-ui/semantic.min.js' %}"></script>
     <script>const LANG_PREFIX = {% if LANGUAGE_CODE == 'nb' %} "" {% else %} "/{{ LANGUAGE_CODE }}" {% endif %};</script>
     {# Temporary fix for CKEditor not being able to find its static files (see https://django-ckeditor.readthedocs.io/en/latest/#required) #}

--- a/web/templates/web/delete_modal.html
+++ b/web/templates/web/delete_modal.html
@@ -9,7 +9,7 @@
         <i class="trash icon"></i>
         <span class="prompt">{% trans "Are you sure you want to delete?" %}</span>
     </div>
-    <form id="delete-form" method="POST">{% csrf_token %}</form>
+    <form id="delete-form" class="dont-prevent-leaving" method="POST">{% csrf_token %}</form>
     <div class="actions">
         <div class="ui red inverted delete button">
             <i class="trash icon"></i>

--- a/web/templates/web/header.html
+++ b/web/templates/web/header.html
@@ -150,7 +150,7 @@
 {% endblock announcements %}
 
 {# This form is hidden, but is submitted through jQuery #}
-<form id="lang-form" action="{% url 'set_language' %}" method="POST">
+<form id="lang-form" class="dont-prevent-leaving" action="{% url 'set_language' %}" method="POST">
     {% csrf_token %}
     {% if LANGUAGE_CODE == "en" %}
         <input name="language" type="hidden" value="nb"/>

--- a/web/templates/web/login.html
+++ b/web/templates/web/login.html
@@ -12,7 +12,7 @@
 {% block body %}
 
     <div class="ui container">
-        <form class="ui form" method="POST">
+        <form class="dont-prevent-leaving ui form" method="POST">
             {% csrf_token %}
             {{ form.non_field_errors }}
             <div class="ui two fields">


### PR DESCRIPTION
This adds a library [jquery.dirty](https://github.com/simon-reynolds/jquery.dirty) and a script (in [common_utils.js](https://github.com/MAKENTNU/web/blob/e8a06e438496b4f9030dfb62ce4e507ea712f089/web/static/web/js/common_utils.js#L9-L13)) which make all forms on the site prompt users before leaving a page, when a form on that page has been "dirtied" (modified).
*Individual forms can opt out of this by adding the `dont-prevent-leaving` class.*