### PR TITLE
Rework of some of the reservation validation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ A summary of changes made to the codebase, grouped per deployment.
 - Made the red "Canceled" ribbon on tickets transparent when clicking / hovering over it, to be able to read the text behind it
 - Added a "help text" yellow question mark icon next to the "Discord username" field in member info forms
   (displayed when clicked / hovered over)
+- Made the user dropdowns on both [the quota admin page](https://makentnu.no/reservation/quota/) and
+  [the quota form page](https://makentnu.no/reservation/quota/create/), function equally
 - Place files uploaded through CKEditor in a separate folder for each model
 - Made all pages have a consistent (browser tab) title format
   - Most pages will have " | MAKE NTNU" as suffix to the title;
@@ -44,6 +46,7 @@ A summary of changes made to the codebase, grouped per deployment.
 
 ### Fixes
 
+- Fixed users being unable to mark reservations as finished when the machine's status is set to "Out of order" or "Maintenance"
 - Fixed admins not being able to cancel other users' tickets
 - Made the CKEditor file uploader work on all subdomains
 - Fixed logging out not working on subdomains other than the "main" subdomain (https://makentnu.no/)

--- a/make_queue/formfields.py
+++ b/make_queue/formfields.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.safestring import mark_safe
 
 from users.models import User
 
@@ -6,4 +7,4 @@ from users.models import User
 class UserModelChoiceField(forms.ModelChoiceField):
 
     def label_from_instance(self, obj: User):
-        return f"{obj.get_full_name()} - {obj.username}"
+        return mark_safe(f"{obj.get_full_name()} &nbsp;&ndash;&nbsp; {obj.username}")

--- a/make_queue/forms.py
+++ b/make_queue/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import Q
+from django.db.models.functions import Concat
 from django.utils import timezone
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
@@ -122,7 +123,7 @@ class ReservationRuleForm(forms.ModelForm):
 
 class QuotaForm(forms.ModelForm):
     user = UserModelChoiceField(
-        queryset=User.objects.all(),
+        queryset=User.objects.order_by(Concat('first_name', 'last_name'), 'username'),
         widget=SemanticSearchableChoiceInput(prompt_text=_("Select user")),
         # `capfirst()` to avoid duplicate translation differing only in case
         label=capfirst(_("user")),

--- a/make_queue/static/make_queue/js/admin_quota_panel.js
+++ b/make_queue/static/make_queue/js/admin_quota_panel.js
@@ -6,6 +6,8 @@ $(".tabular.menu .item").tab();
 
 const $userDropdown = $("#user").parent();
 $userDropdown.dropdown({
+    fullTextSearch: true,
+    forceSelection: true,
     onChange: function (userPK, text, $choice) {
         $.ajax(`${LANG_PREFIX}/reservation/quota/user/${userPK}/`, {
             success: function (data, textStatus) {

--- a/make_queue/templates/make_queue/quota/admin_quota_panel.html
+++ b/make_queue/templates/make_queue/quota/admin_quota_panel.html
@@ -63,7 +63,7 @@
                 <div class="default text">{% translate "Select user" %}</div>
                 <div class="menu">
                     {% for user in users %}
-                        <div class="item" data-value="{{ user.pk }}">{{ user.get_full_name }}</div>
+                        <div class="item" data-value="{{ user.pk }}">{{ user.get_full_name }} &nbsp;&ndash;&nbsp; {{ user.username }}</div>
                     {% endfor %}
                 </div>
             </div>

--- a/make_queue/templates/make_queue/reservation_form.html
+++ b/make_queue/templates/make_queue/reservation_form.html
@@ -113,7 +113,7 @@
                 <div class="field">
                     <label>{% translate "end time"|capfirst %}</label>
                     <div id="end-time" class="ui calendar">
-                        <div class="ui input left icon">
+                        <div class="ui input {% if not can_change_end_time %}disabled{% endif %} left icon">
                             <i class="calendar icon"></i>
                             <input name="end_time" type="text" placeholder="{% translate "end time"|capfirst %}" value="{% spaceless %}
                                 {% if end_time %}

--- a/make_queue/templatetags/reservation_extra.py
+++ b/make_queue/templatetags/reservation_extra.py
@@ -94,12 +94,12 @@ def reservation_denied_message(user: User, machine: Machine):
 
 @register.simple_tag
 def can_change_reservation(reservation: Reservation, user: User):
-    return reservation.can_change(user) or reservation.can_change_end_time(user)
+    return reservation.can_be_changed_by(user) and (reservation.can_change_start_time() or reservation.can_change_end_time())
 
 
 @register.simple_tag
 def can_delete_reservation(reservation: Reservation, user: User):
-    return reservation.can_delete(user)
+    return reservation.can_be_deleted_by(user)
 
 
 @register.simple_tag

--- a/make_queue/tests/models/test_reservation.py
+++ b/make_queue/tests/models/test_reservation.py
@@ -14,6 +14,7 @@ from util.locale_utils import parse_datetime_localized
 from ...models.course import Printer3DCourse
 from ...models.machine import Machine, MachineType
 from ...models.reservation import Quota, Reservation, ReservationRule
+from ...templatetags.reservation_extra import can_change_reservation
 
 
 Day = ReservationRule.Day
@@ -235,15 +236,19 @@ class TestReservation(ReservationTestBase):
             "Reservations on different printers should be able to overlap in time")
 
     def test_can_owner_change_future_reservation(self):
-        self.assertTrue(self.create_reservation(timedelta(hours=1), timedelta(hours=2)).can_change(self.user_with_course_and_quota))
+        reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
 
     def test_can_owner_change_started_reservation(self):
-        self.assertFalse(self.create_reservation(timedelta(hours=-1), timedelta(hours=2)).can_change(self.user_with_course_and_quota))
+        reservation = self.create_reservation(timedelta(hours=-1), timedelta(hours=2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertFalse(reservation.can_change_start_time())
+        self.assertTrue(reservation.can_change_end_time())
 
     def test_can_owner_change_end_time_of_started_reservation(self):
         reservation = self.create_reservation(timedelta(hours=-2), timedelta(hours=2))
         self.save_past_reservation(reservation)
-        self.assertTrue(reservation.can_change_end_time(self.user_with_course_and_quota))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
         reservation.end_time = timezone.now() + timedelta(hours=1)
         self.check_reservation_valid(reservation, "Should be able to change end time of started reservation")
         reservation.end_time = timezone.now() + timedelta(hours=-1)
@@ -251,28 +256,27 @@ class TestReservation(ReservationTestBase):
                                        "Should not be able to change end time of started reservation to before the current time")
 
     def test_can_owner_change_end_time_of_ended_reservation(self):
-        self.assertFalse(
-            self.create_reservation(timedelta(hours=-3), timedelta(hours=-1)).can_change_end_time(self.user_with_course_and_quota))
+        reservation = self.create_reservation(timedelta(hours=-3), timedelta(hours=-1))
+        self.assertFalse(can_change_reservation(reservation, self.user_with_course_and_quota))
 
     def test_can_owner_change_started_event_reservation(self):
         self.give_user_event_permission()
 
-        self.assertTrue(
-            self.create_reservation(timedelta(hours=-1), timedelta(hours=2), event=self.timeplace).can_change(
-                self.user_with_course_and_quota))
+        reservation = self.create_reservation(timedelta(hours=-1), timedelta(hours=2), event=self.timeplace)
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
 
     def test_can_owner_change_started_special_reservation(self):
         self.give_user_event_permission()
 
-        self.assertTrue(self.create_reservation(timedelta(hours=-1), timedelta(hours=2), special=True,
-                                                special_text="Test").can_change(self.user_with_course_and_quota))
+        reservation = self.create_reservation(timedelta(hours=-1), timedelta(hours=2), special=True, special_text="Test")
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
 
     def test_can_other_user_change_future_reservation(self):
         user2 = User.objects.create_user("test", "user2@makentnu.no", "test_pass")
         reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2))
 
-        self.assertTrue(reservation.can_change(self.user_with_course_and_quota))
-        self.assertFalse(reservation.can_change(user2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertFalse(can_change_reservation(reservation, user2))
 
     def test_can_user_with_event_reservation_change_other_user_non_event_reservation(self):
         user2 = User.objects.create_user("test", "user2@makentnu.no", "test_pass")
@@ -280,8 +284,8 @@ class TestReservation(ReservationTestBase):
 
         reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2))
 
-        self.assertTrue(reservation.can_change(self.user_with_course_and_quota))
-        self.assertFalse(reservation.can_change(user2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertFalse(can_change_reservation(reservation, user2))
 
     def test_can_user_with_event_reservation_change_other_user_event_reservation(self):
         self.give_user_event_permission()
@@ -290,8 +294,8 @@ class TestReservation(ReservationTestBase):
 
         reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2), event=self.timeplace)
 
-        self.assertTrue(reservation.can_change(self.user_with_course_and_quota))
-        self.assertTrue(reservation.can_change(user2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertTrue(can_change_reservation(reservation, user2))
 
     def test_can_user_with_event_reservation_change_other_user_special_reservation(self):
         self.give_user_event_permission()
@@ -300,8 +304,8 @@ class TestReservation(ReservationTestBase):
 
         reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2), special=True, special_text="Test")
 
-        self.assertTrue(reservation.can_change(self.user_with_course_and_quota))
-        self.assertTrue(reservation.can_change(user2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertTrue(can_change_reservation(reservation, user2))
 
     def test_can_user_without_event_reservation_change_other_user_special_reservation(self):
         self.give_user_event_permission()
@@ -309,8 +313,8 @@ class TestReservation(ReservationTestBase):
 
         reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2), special=True, special_text="Test")
 
-        self.assertTrue(reservation.can_change(self.user_with_course_and_quota))
-        self.assertFalse(reservation.can_change(user2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertFalse(can_change_reservation(reservation, user2))
 
     def test_can_user_without_event_reservation_change_other_user_event_reservation(self):
         self.give_user_event_permission()
@@ -318,14 +322,14 @@ class TestReservation(ReservationTestBase):
 
         reservation = self.create_reservation(timedelta(hours=1), timedelta(hours=2), event=self.timeplace)
 
-        self.assertTrue(reservation.can_change(self.user_with_course_and_quota))
-        self.assertFalse(reservation.can_change(user2))
+        self.assertTrue(can_change_reservation(reservation, self.user_with_course_and_quota))
+        self.assertFalse(can_change_reservation(reservation, user2))
 
     def test_can_delete_future_reservation(self):
-        self.assertTrue(self.create_reservation(timedelta(hours=1), timedelta(hours=2)).can_delete(self.user_with_course_and_quota))
+        self.assertTrue(self.create_reservation(timedelta(hours=1), timedelta(hours=2)).can_be_deleted_by(self.user_with_course_and_quota))
 
     def test_cannot_delete_started_reservation(self):
-        self.assertFalse(self.create_reservation(timedelta(hours=-1), timedelta(hours=2)).can_delete(self.user_with_course_and_quota))
+        self.assertFalse(self.create_reservation(timedelta(hours=-1), timedelta(hours=2)).can_be_deleted_by(self.user_with_course_and_quota))
 
     def test_is_within_allowed_period_for_reservation(self):
         Reservation.FUTURE_LIMIT = timedelta(days=7)

--- a/make_queue/tests/views/test_delete_reservation_view.py
+++ b/make_queue/tests/views/test_delete_reservation_view.py
@@ -79,3 +79,18 @@ class TestDeleteReservationView(TestCase):
         response = self.client1.delete(reverse('delete_reservation', args=[self.reservation.pk]))
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertFalse(Reservation.objects.filter(pk=self.reservation.pk).exists())
+
+    def test_can_cancel_existing_reservation_for_machine_out_of_order(self):
+        self._test_can_cancel_existing_reservation_for_machine_with_status(Machine.Status.OUT_OF_ORDER)
+
+    def test_can_cancel_existing_reservation_for_machine_on_maintenance(self):
+        self._test_can_cancel_existing_reservation_for_machine_with_status(Machine.Status.MAINTENANCE)
+
+    def _test_can_cancel_existing_reservation_for_machine_with_status(self, machine_status: Machine.Status):
+        machine = self.reservation.machine
+        machine.status = machine_status
+        machine.save()
+
+        response = self.client1.delete(reverse('delete_reservation', args=[self.reservation.pk]))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertFalse(Reservation.objects.filter(pk=self.reservation.pk).exists())

--- a/make_queue/tests/views/test_quota_views.py
+++ b/make_queue/tests/views/test_quota_views.py
@@ -47,7 +47,7 @@ class TestQuotaPanelView(TestCase):
             response = self.superuser_client.get(url)
             context = response.context
             self.assertIs(type(context['view']), QuotaPanelView)
-            self.assertListEqual(list(context['users']), [self.user, self.user2, self.superuser])
+            self.assertListEqual(list(context['users']), [self.superuser, self.user, self.user2])
             self.assertListEqual(list(context['global_quotas']), [self.quota1, self.quota2])
             self.assertEqual(context['requested_user'], expected_requested_user)
 

--- a/make_queue/tests/views/test_reservation_reservation.py
+++ b/make_queue/tests/views/test_reservation_reservation.py
@@ -162,14 +162,21 @@ class TestCreateOrEditReservationView(CreateOrEditReservationViewTestBase):
         context_data["machine_types"] = set(context_data["machine_types"])
 
         self.assertDictEqual(context_data, {
-            "can_change_start_time": True, "event_timeplaces": [self.timeplace], "new_reservation": False,
+            "can_change_start_time": True,
+            "event_timeplaces": [self.timeplace],
+            "new_reservation": False,
             "machine_types": {
                 machine_type for machine_type in MachineType.objects.all()
                 if machine_type.can_user_use(self.user)
             },
-            "start_time": reservation.start_time, "end_time": reservation.end_time, "selected_machine": self.machine,
-            "event": self.timeplace, "special": False, "special_text": "",
-            "maximum_days_in_advance": Reservation.FUTURE_LIMIT.days, "comment": "Comment",
+            "start_time": reservation.start_time,
+            "end_time": reservation.end_time,
+            "selected_machine": self.machine,
+            "event": self.timeplace,
+            "special": False,
+            "special_text": "",
+            "maximum_days_in_advance": Reservation.FUTURE_LIMIT.days,
+            "comment": "Comment",
             "reservation_pk": reservation.pk,
         })
 
@@ -181,12 +188,14 @@ class TestCreateOrEditReservationView(CreateOrEditReservationViewTestBase):
 
         self.assertDictEqual(context_data, {
             "can_change_start_time": True,
-            "event_timeplaces": [self.timeplace], "new_reservation": True,
+            "event_timeplaces": [self.timeplace],
+            "new_reservation": True,
             "machine_types": {
                 machine_type for machine_type in MachineType.objects.all()
                 if machine_type.can_user_use(self.user)
             },
-            "start_time": start_time, "selected_machine": self.machine,
+            "start_time": start_time,
+            "selected_machine": self.machine,
             "maximum_days_in_advance": Reservation.FUTURE_LIMIT.days,
         })
 
@@ -505,7 +514,7 @@ class TestMarkReservationFinishedView(TestCase):
 
     @patch('django.utils.timezone.now')
     def test_valid_post_request_succeeds(self, now_mock):
-        # Lock the return value of `timezone.now()` and set it to 1 minute after `self.reservation1` has started
+        # Freeze the return value of `timezone.now()` and set it to 1 minute after `self.reservation1` has started
         now_mock.return_value = self.now + timedelta(hours=1, minutes=1)
         self.assertTrue(self.reservation1.can_change_end_time(self.user))
 
@@ -536,7 +545,7 @@ class TestMarkReservationFinishedView(TestCase):
 
     @patch('django.utils.timezone.now')
     def test_finishing_just_before_other_reservation_starts_succeeds(self, now_mock):
-        # Lock the return value of `timezone.now()`
+        # Freeze the return value of `timezone.now()`
         now_mock.return_value = self.now
 
         self.reservation1.delete()

--- a/make_queue/tests/views/test_reservation_reservation.py
+++ b/make_queue/tests/views/test_reservation_reservation.py
@@ -164,6 +164,7 @@ class TestCreateOrEditReservationView(CreateOrEditReservationViewTestBase):
 
         self.assertDictEqual(context_data, {
             "can_change_start_time": True,
+            "can_change_end_time": True,
             "event_timeplaces": [self.timeplace],
             "new_reservation": False,
             "machine_types": {
@@ -189,6 +190,7 @@ class TestCreateOrEditReservationView(CreateOrEditReservationViewTestBase):
 
         self.assertDictEqual(context_data, {
             "can_change_start_time": True,
+            "can_change_end_time": True,
             "event_timeplaces": [self.timeplace],
             "new_reservation": True,
             "machine_types": {

--- a/make_queue/tests/views/test_reservation_reservation.py
+++ b/make_queue/tests/views/test_reservation_reservation.py
@@ -19,6 +19,7 @@ from ...forms import ReservationForm
 from ...models.course import Printer3DCourse
 from ...models.machine import Machine, MachineType
 from ...models.reservation import Quota, Reservation, ReservationRule
+from ...templatetags.reservation_extra import can_change_reservation
 from ...views.admin.reservation import MAKEReservationsListView
 from ...views.reservation.reservation import CreateReservationView, EditReservationView
 
@@ -516,7 +517,7 @@ class TestMarkReservationFinishedView(TestCase):
     def test_valid_post_request_succeeds(self, now_mock):
         # Freeze the return value of `timezone.now()` and set it to 1 minute after `self.reservation1` has started
         now_mock.return_value = self.now + timedelta(hours=1, minutes=1)
-        self.assertTrue(self.reservation1.can_change_end_time(self.user))
+        self.assertTrue(can_change_reservation(self.reservation1, self.user))
 
         response = self.post_to(self.reservation1)
         self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/make_queue/views/admin/quota.py
+++ b/make_queue/views/admin/quota.py
@@ -1,6 +1,7 @@
 from abc import ABC
 
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.db.models.functions import Concat
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -35,7 +36,7 @@ class QuotaPanelView(PermissionRequiredMixin, TemplateView):
         :return: A list of all users
         """
         return super().get_context_data(**{
-            'users': User.objects.all(),
+            'users': User.objects.order_by(Concat('first_name', 'last_name'), 'username'),
             'global_quotas': Quota.objects.filter(all=True),
             'requested_user': self.user,
             **kwargs,

--- a/make_queue/views/reservation/reservation.py
+++ b/make_queue/views/reservation/reservation.py
@@ -17,7 +17,7 @@ from util.view_utils import PreventGetRequestsMixin
 from ...forms import FreeSlotForm, ReservationForm
 from ...models.machine import Machine, MachineType
 from ...models.reservation import Reservation, ReservationRule
-from ...templatetags.reservation_extra import calendar_url_reservation, can_delete_reservation, can_mark_reservation_finished
+from ...templatetags.reservation_extra import calendar_url_reservation, can_change_reservation, can_delete_reservation, can_mark_reservation_finished
 
 
 # TODO: rewrite this whole view (and everything that uses it),
@@ -116,7 +116,7 @@ class CreateOrEditReservationView(TemplateView, ABC):
             context_data["special"] = reservation.special
             context_data["special_text"] = reservation.special_text
             context_data["comment"] = reservation.comment
-            context_data["can_change_start_time"] = reservation.can_change(self.request.user)
+            context_data["can_change_start_time"] = reservation.can_change_start_time()
         # Otherwise populate with default information given to the view
         else:
             if hasattr(self, 'machine'):
@@ -250,7 +250,7 @@ class EditReservationView(CreateOrEditReservationView):
         """
         reservation = self.reservation
         # User must be able to change the given reservation
-        if reservation.can_change(request.user) or reservation.can_change_end_time(request.user):
+        if can_change_reservation(reservation, request.user):
             return super().dispatch(request, *args, **kwargs)
         else:
             return redirect('my_reservations_list')

--- a/make_queue/views/reservation/reservation.py
+++ b/make_queue/views/reservation/reservation.py
@@ -117,6 +117,7 @@ class CreateOrEditReservationView(TemplateView, ABC):
             context_data["special_text"] = reservation.special_text
             context_data["comment"] = reservation.comment
             context_data["can_change_start_time"] = reservation.can_change_start_time()
+            context_data["can_change_end_time"] = reservation.can_change_end_time()
         # Otherwise populate with default information given to the view
         else:
             if hasattr(self, 'machine'):
@@ -129,6 +130,7 @@ class CreateOrEditReservationView(TemplateView, ABC):
             if "start_time" in kwargs:
                 context_data["start_time"] = kwargs["start_time"]
             context_data["can_change_start_time"] = True
+            context_data["can_change_end_time"] = True
 
         return context_data
 

--- a/util/url_utils.py
+++ b/util/url_utils.py
@@ -8,9 +8,6 @@ from django.urls import include, path
 from django.views.decorators.cache import never_cache
 from django_hosts import reverse
 
-from dataporten import views as dataporten_views
-from users.models import User
-
 
 def reverse_internal(viewname: str, *args):
     return reverse(viewname, args=args, host='internal', host_args=['i'])
@@ -23,6 +20,7 @@ def permission_required_else_denied(perm, login_url=None):
     When the user does not have the permission, they will be redirected to the login page if not logged in,
     and a ``PermissionDenied`` will be raised if already logged in.
     """
+    from users.models import User  # Avoids circular importing
 
     def check_perms(user: User):
         if not user.is_authenticated:
@@ -48,6 +46,8 @@ def logout_urls():
     subdomains (i.e. pressing the "Log out" button), multiple browsers (like Chrome) send an ``Origin`` header with a value of ``null``, which causes
     the CSRF verification to always fail.
     """
+    from dataporten import views as dataporten_views  # Avoids circular importing
+
     # Both of these views log the user out, then redirects to the value of the `LOGOUT_REDIRECT_URL` setting
     if settings.USES_DATAPORTEN_AUTH:
         logout_view = dataporten_views.Logout.as_view()


### PR DESCRIPTION
## Proposed changes

### Improvements

- Refactored the `can_change[...]` methods of `Reservation` (2a6a92fcc8cae034f77040552eee3d4a2280b2bf)
- **Reworked some of the reservation validation logic** (3a271bfa1f3a5610e60b42f41969ef5c6a1166c5)
- Disable `end_time` in reservation form if the user can't change it (f1680ccb4aa798269b4ec1c77fc89e3e405cddab)
- Also made the user dropdowns on both the quota admin page and the quota form page, function equally (a5fdd91499dd7cfeb0dbdf30e38a4f2f69075b4d)

### Fixes

- **Fixed users being unable to mark reservations as finished when the machine's status is set to `OUT_OF_ORDER` or `MAINTENANCE`** (57ed8221d78ac33f08e3424b4df95e0ddc41d84f)

### Other changes

- A little code cleanup (59a24160a2ae5444ed8828ce743b22abe5557cf8)


## Areas to review closely

That the reservation logic works as intended.


## Checklist

_(If any of the points are not relevant, mark them as checked)_

- [x] Created tests that fail without the changes, if relevant/possible
- [x] Made sure that your code conforms to [the code style guides](https://github.com/MAKENTNU/web/blob/main/CONTRIBUTING.md#code-style-guides) and that any [common code smells](https://github.com/MAKENTNU/web/blob/main/CONTRIBUTING.md#code-review-guideline-code-smells) have been addressed
  - (It's not intended that you read through this whole document, but that you get yourself an overview over its contents, and that you keep it in mind while taking a second look at your code before opening a pull request)
- [x] Added sufficient documentation - e.g. as docstrings or in the [README](https://github.com/MAKENTNU/web/blob/main/README.md), if suitable
- [x] Added your changes to the ["Unreleased" section of the changelog](https://github.com/MAKENTNU/web/blob/main/CHANGELOG.md#unreleased) - mainly the changes that are of particular interest to users and/or developers, if any
- [x] Added a "Deployment notes" section above, if anything out of the ordinary should be done when deploying these changes to the server
