### PR TITLE
Remove explicit copyright end year from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2023 MAKE NTNU
+Copyright (c) 2017-present, MAKE NTNU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Proposed changes

Constantly having to keep this year updated to the present year seems to simply be a long-standing norm in the open source community, rather than something that's legally required.

There doesn't seem to be a consensus on exactly what to remove and what to keep, however, so replacing the end year with "present" seems like the most conservative option that still removes the need to constantly keep the year updated.

This was inspired by https://github.com/tox-dev/tox/pull/2941, which also links to a couple other "testimonies":
- https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/
- https://hynek.me/til/copyright-years/


## Areas to review closely

<!-- Refer to areas of the changed code where you would like reviewers to take a closer look -->


## Checklist

_(If any of the points are not relevant, mark them as checked)_

- [x] Created tests that fail without the changes, if relevant/possible
- [x] Made sure that your code conforms to [the code style guides](https://github.com/MAKENTNU/web/blob/main/CONTRIBUTING.md#code-style-guides) and that any [common code smells](https://github.com/MAKENTNU/web/blob/main/CONTRIBUTING.md#code-review-guideline-code-smells) have been addressed
  - (It's not intended that you read through this whole document, but that you get yourself an overview over its contents, and that you keep it in mind while taking a second look at your code before opening a pull request)
- [x] Added sufficient documentation - e.g. as docstrings or in the [README](https://github.com/MAKENTNU/web/blob/main/README.md), if suitable
- [x] Added your changes to the ["Unreleased" section of the changelog](https://github.com/MAKENTNU/web/blob/main/CHANGELOG.md#unreleased) - mainly the changes that are of particular interest to users and/or developers, if any
- [x] Added a "Deployment notes" section above, if anything out of the ordinary should be done when deploying these changes to the server
